### PR TITLE
Update program API

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -48,7 +48,6 @@ use {
         pubkey::Pubkey,
         rent::Rent,
         slot_hashes::SlotHashes,
-        system_program,
         transaction_context::{InstructionAccount, TransactionContext},
     },
     std::sync::Arc,
@@ -78,12 +77,13 @@ impl Default for Mollusk {
              solana_runtime::message_processor=debug,\
              solana_runtime::system_instruction_processor=trace",
         );
+        let (program_id, program_account) = program::system_program();
         Self {
             compute_budget: ComputeBudget::default(),
             feature_set: FeatureSet::all_enabled(),
-            program_account: program::system_program_account(),
+            program_account,
             program_cache: program::default_program_cache(),
-            program_id: system_program::id(),
+            program_id,
             sysvar_cache: sysvar::default_sysvar_cache(),
         }
     }
@@ -100,7 +100,7 @@ impl Mollusk {
 
         let mut mollusk = Self {
             program_id: *program_id,
-            program_account: program::create_program_account(program_id),
+            program_account: program::program_account(program_id),
             ..Default::default()
         };
 

--- a/harness/tests/bpf_program.rs
+++ b/harness/tests/bpf_program.rs
@@ -1,6 +1,6 @@
 use {
     mollusk_svm::{
-        program::{create_program_account, system_program_account},
+        program::{program_account, system_program},
         result::Check,
         Mollusk,
     },
@@ -128,7 +128,7 @@ fn test_transfer() {
             &[
                 (payer, payer_account.clone()),
                 (recipient, recipient_account.clone()),
-                (system_program::id(), system_program_account()),
+                system_program(),
             ],
             &[
                 Check::err(ProgramError::MissingRequiredSignature),
@@ -144,7 +144,7 @@ fn test_transfer() {
             &[
                 (payer, AccountSharedData::default()),
                 (recipient, recipient_account.clone()),
-                (system_program::id(), system_program_account()),
+                system_program(),
             ],
             &[
                 Check::err(ProgramError::Custom(
@@ -161,7 +161,7 @@ fn test_transfer() {
         &[
             (payer, payer_account.clone()),
             (recipient, recipient_account.clone()),
-            (system_program::id(), system_program_account()),
+            system_program(),
         ],
         &[
             Check::success(),
@@ -207,7 +207,7 @@ fn test_close_account() {
             &[
                 (key, account.clone()),
                 (incinerator::id(), AccountSharedData::default()),
-                (system_program::id(), system_program_account()),
+                system_program(),
             ],
             &[
                 Check::err(ProgramError::MissingRequiredSignature),
@@ -222,7 +222,7 @@ fn test_close_account() {
         &[
             (key, account.clone()),
             (incinerator::id(), AccountSharedData::default()),
-            (system_program::id(), system_program_account()),
+            system_program(),
         ],
         &[
             Check::success(),
@@ -287,7 +287,7 @@ fn test_cpi() {
                 (key, account.clone()),
                 (
                     cpi_target_program_id,
-                    create_program_account(&cpi_target_program_id),
+                    program_account(&cpi_target_program_id),
                 ),
             ],
             &[
@@ -312,7 +312,7 @@ fn test_cpi() {
                 (key, account.clone()),
                 (
                     cpi_target_program_id,
-                    create_program_account(&cpi_target_program_id),
+                    program_account(&cpi_target_program_id),
                 ),
             ],
             &[
@@ -336,7 +336,7 @@ fn test_cpi() {
                 (key, account.clone()),
                 (
                     cpi_target_program_id,
-                    create_program_account(&cpi_target_program_id),
+                    program_account(&cpi_target_program_id),
                 ),
             ],
             &[
@@ -353,7 +353,7 @@ fn test_cpi() {
             (key, account.clone()),
             (
                 cpi_target_program_id,
-                create_program_account(&cpi_target_program_id),
+                program_account(&cpi_target_program_id),
             ),
         ],
         &[


### PR DESCRIPTION
Update the program API - methods like `system_program_account` to return
a `(Pubkey, AccountSharedData)` for use in test runs.

Renames the like to just `system_program()`.