### PR TITLE
Add BPF Loader 2 to cache

### DIFF
--- a/harness/src/program.rs
+++ b/harness/src/program.rs
@@ -40,7 +40,7 @@ impl ProgramCache {
         &self.cache
     }
 
-    /// Add a program to a program cache.
+    /// Add a program to the cache.
     pub fn add_program(
         &mut self,
         program_id: &Pubkey,
@@ -70,9 +70,16 @@ impl ProgramCache {
             ),
         );
     }
+
+    /// Add a builtin program to the cache.
+    pub fn add_builtin(&mut self, builtin: Builtin) {
+        let program_id = builtin.program_id;
+        let entry = builtin.program_cache_entry();
+        self.cache.replenish(program_id, entry);
+    }
 }
 
-struct Builtin {
+pub struct Builtin {
     program_id: Pubkey,
     name: &'static str,
     entrypoint: BuiltinFunctionWithContext,

--- a/harness/src/program.rs
+++ b/harness/src/program.rs
@@ -95,6 +95,11 @@ static BUILTINS: &[Builtin] = &[
         entrypoint: solana_system_program::system_processor::Entrypoint::vm,
     },
     Builtin {
+        program_id: bpf_loader::id(),
+        name: "solana_bpf_loader_program",
+        entrypoint: solana_bpf_loader_program::Entrypoint::vm,
+    },
+    Builtin {
         program_id: bpf_loader_upgradeable::id(),
         name: "solana_bpf_loader_upgradeable_program",
         entrypoint: solana_bpf_loader_program::Entrypoint::vm,

--- a/scripts/build-test-programs.sh
+++ b/scripts/build-test-programs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cargo build-sbf --manifest-path test-programs/cpi-target/Cargo.toml
+cargo build-sbf --manifest-path test-programs/primary/Cargo.toml


### PR DESCRIPTION
Add the BPF Loader 2 to the default program cache. This allows Mollusk
to support CPI to BPF Loader 2 programs.

cc @OliverNChalk