### PR TITLE
Fix: slot hash warping

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -52,7 +52,6 @@ use {
         hash::Hash,
         instruction::Instruction,
         pubkey::Pubkey,
-        rent::Rent,
         transaction_context::{InstructionAccount, TransactionContext},
     },
     std::sync::Arc,
@@ -225,7 +224,7 @@ impl Mollusk {
 
         let mut transaction_context = TransactionContext::new(
             transaction_accounts,
-            Rent::default(),
+            self.sysvars.rent.clone(),
             self.compute_budget.max_instruction_stack_depth,
             self.compute_budget.max_instruction_trace_length,
         );


### PR DESCRIPTION
Adds a fix for updating the `SlotHashes` sysvar when warping to a slot.

Simply uses `SlotHashes::add` instead of overwriting the slice, allowing the binary search method to pop expired entries out.

The first commit has nothing to do with warping slots, but it managed to squeak in here, so it's hitching a ride.