### PR TITLE
Harness: Dedupe accounts and coalesce privileges

### DIFF
--- a/harness/tests/bpf_program.rs
+++ b/harness/tests/bpf_program.rs
@@ -48,10 +48,7 @@ fn test_write_data() {
         mollusk.process_and_validate_instruction(
             &account_not_signer_ix,
             &[(key, account.clone())],
-            &[
-                Check::err(ProgramError::MissingRequiredSignature),
-                Check::compute_units(279),
-            ],
+            &[Check::err(ProgramError::MissingRequiredSignature)],
         );
     }
 
@@ -63,10 +60,7 @@ fn test_write_data() {
         mollusk.process_and_validate_instruction(
             &data_too_large_ix,
             &[(key, account.clone())],
-            &[
-                Check::err(ProgramError::AccountDataTooSmall),
-                Check::compute_units(290),
-            ],
+            &[Check::err(ProgramError::AccountDataTooSmall)],
         );
     }
 
@@ -131,10 +125,7 @@ fn test_transfer() {
                 (recipient, recipient_account.clone()),
                 keyed_account_for_system_program(),
             ],
-            &[
-                Check::err(ProgramError::MissingRequiredSignature),
-                Check::compute_units(605),
-            ],
+            &[Check::err(ProgramError::MissingRequiredSignature)],
         );
     }
 
@@ -147,12 +138,9 @@ fn test_transfer() {
                 (recipient, recipient_account.clone()),
                 keyed_account_for_system_program(),
             ],
-            &[
-                Check::err(ProgramError::Custom(
-                    SystemError::ResultWithNegativeLamports as u32,
-                )),
-                Check::compute_units(2261),
-            ],
+            &[Check::err(ProgramError::Custom(
+                SystemError::ResultWithNegativeLamports as u32,
+            ))],
         );
     }
 
@@ -210,10 +198,7 @@ fn test_close_account() {
                 (incinerator::id(), AccountSharedData::default()),
                 keyed_account_for_system_program(),
             ],
-            &[
-                Check::err(ProgramError::MissingRequiredSignature),
-                Check::compute_units(605),
-            ],
+            &[Check::err(ProgramError::MissingRequiredSignature)],
         );
     }
 
@@ -276,7 +261,7 @@ fn test_cpi() {
             &[(key, account.clone())],
             &[
                 Check::err(ProgramError::NotEnoughAccountKeys),
-                Check::compute_units(0),
+                Check::compute_units(0), // No compute units used.
             ],
         );
     }
@@ -296,7 +281,6 @@ fn test_cpi() {
                 // This is the error thrown by SVM. It also emits the message
                 // "Program is not cached".
                 Check::err(ProgramError::InvalidAccountData),
-                Check::compute_units(1840),
             ],
         );
     }
@@ -319,7 +303,6 @@ fn test_cpi() {
             ],
             &[
                 Check::instruction_err(InstructionError::PrivilegeEscalation), // CPI
-                Check::compute_units(1841),
             ],
         );
     }
@@ -341,10 +324,7 @@ fn test_cpi() {
                     create_program_account_loader_v3(&cpi_target_program_id),
                 ),
             ],
-            &[
-                Check::err(ProgramError::AccountDataTooSmall),
-                Check::compute_units(2162),
-            ],
+            &[Check::err(ProgramError::AccountDataTooSmall)],
         );
     }
 

--- a/test-programs/primary/src/lib.rs
+++ b/test-programs/primary/src/lib.rs
@@ -92,6 +92,24 @@ fn process_instruction(
 
             invoke(&instruction, &[account_info.clone()])?;
         }
+        Some((5, _)) => {
+            // Load the same account twice and assert both infos share the
+            // same privilege level.
+            let first_info = next_account_info(accounts_iter)?;
+            let second_info = next_account_info(accounts_iter)?;
+
+            if first_info.key != second_info.key {
+                return Err(ProgramError::InvalidArgument);
+            }
+
+            if first_info.is_writable != second_info.is_writable {
+                return Err(ProgramError::Immutable);
+            }
+
+            if first_info.is_signer != second_info.is_signer {
+                return Err(ProgramError::MissingRequiredSignature);
+            }
+        }
         _ => return Err(ProgramError::InvalidInstructionData),
     }
 


### PR DESCRIPTION
#### Problem
Currently, if you provide the same account twice to Mollusk's `process_instruction` API, the permissions are taken directly from the instruction `AccountMeta` entries, so even if two metas have the same public key, their perms as `AccountInfo` will reflect those of the instruction metas.

In other words, if I provide the same account twice, as so...

```rust
let key = Pubkey::new_unique();
let metas = vec![
    AccountMeta::new(key, false),         // writable
    AccountMeta::new_readonly(key, true), // signer
];
```

... then my program will see the first account as writable, and the second as a signer, but they will have the same address. These must be coalesced, as is done in the VM's serialization step. Unfortunately, this deduping depends on the `TransactionContext`, so this fix has to go into Mollusk!

#### Summary of Changes
Employ a simple map and an extra iteration to coalesce account privileges across accounts with the same address.