### PR TITLE
fix: transaction account dedupe and roles

### DIFF
--- a/harness/src/keys.rs
+++ b/harness/src/keys.rs
@@ -1,0 +1,168 @@
+//! Instruction <-> Transaction key deduplication and privilege handling.
+//!
+//! Solana instructions and transactions are designed to be intentionally
+//! verbosely declarative, to provide the runtime with granular directives
+//! for manipulating chain state.
+//!
+//! As a result, when a transaction is _compiled_, many steps occur:
+//! * Ensuring there is a fee payer.
+//! * Ensuring there is a signature.
+//! * Deduplicating account keys.
+//! * Configuring the highest role awarded to each account key.
+//! * ...
+//!
+//! Since Mollusk does not use transactions or fee payers, the deduplication
+//! of account keys and handling of roles are the only two steps necessary
+//! to perform under the hood within the harness.
+//!
+//! This implementation closely follows the implementation in the Anza SDK
+//! for `Message::new_with_blockhash`. For more information, see:
+//! <https://github.com/anza-xyz/agave/blob/c6e8239843af8e6301cd198e39d0a44add427bef/sdk/program/src/message/legacy.rs#L357>.
+
+use {
+    solana_sdk::{
+        account::{AccountSharedData, WritableAccount},
+        instruction::Instruction,
+        pubkey::Pubkey,
+        transaction_context::{IndexOfAccount, InstructionAccount, TransactionAccount},
+    },
+    std::collections::HashMap,
+};
+
+struct KeyMap(HashMap<Pubkey, (bool, bool)>);
+
+impl KeyMap {
+    fn compile(instruction: &Instruction) -> Self {
+        let mut map: HashMap<Pubkey, (bool, bool)> = HashMap::new();
+        map.entry(instruction.program_id).or_default();
+        for meta in instruction.accounts.iter() {
+            let entry = map.entry(meta.pubkey).or_default();
+            entry.0 |= meta.is_signer;
+            entry.1 |= meta.is_writable;
+        }
+        Self(map)
+    }
+
+    fn is_signer(&self, key: &Pubkey) -> bool {
+        self.0.get(key).map(|(s, _)| *s).unwrap_or(false)
+    }
+
+    fn is_writable(&self, key: &Pubkey) -> bool {
+        self.0.get(key).map(|(_, w)| *w).unwrap_or(false)
+    }
+}
+
+struct Keys<'a> {
+    keys: Vec<&'a Pubkey>,
+    key_map: &'a KeyMap,
+}
+
+impl<'a> Keys<'a> {
+    fn new(key_map: &'a KeyMap) -> Self {
+        Self {
+            keys: key_map.0.keys().collect(),
+            key_map,
+        }
+    }
+
+    fn position(&self, key: &Pubkey) -> u8 {
+        self.keys.iter().position(|k| *k == key).unwrap() as u8
+    }
+
+    fn is_signer(&self, index: usize) -> bool {
+        self.key_map.is_signer(self.keys[index])
+    }
+
+    fn is_writable(&self, index: usize) -> bool {
+        self.key_map.is_writable(self.keys[index])
+    }
+}
+
+// Helper struct so Mollusk doesn't have to clone instruction data.
+struct CompiledInstructionWithoutData {
+    program_id_index: u8,
+    accounts: Vec<u8>,
+}
+
+pub struct CompiledAccounts {
+    pub program_id_index: u16,
+    pub instruction_accounts: Vec<InstructionAccount>,
+    pub transaction_accounts: Vec<TransactionAccount>,
+}
+
+pub fn compile_accounts(
+    instruction: &Instruction,
+    accounts: &[(Pubkey, AccountSharedData)],
+    loader_key: Pubkey,
+) -> CompiledAccounts {
+    let key_map = KeyMap::compile(instruction);
+    let keys = Keys::new(&key_map);
+
+    let compiled_instruction = CompiledInstructionWithoutData {
+        program_id_index: keys.position(&instruction.program_id),
+        accounts: instruction
+            .accounts
+            .iter()
+            .map(|account_meta| keys.position(&account_meta.pubkey))
+            .collect(),
+    };
+
+    let instruction_accounts: Vec<InstructionAccount> = compiled_instruction
+        .accounts
+        .iter()
+        .enumerate()
+        .map(|(ix_account_index, &index_in_transaction)| {
+            let index_in_callee = compiled_instruction
+                .accounts
+                .get(0..ix_account_index)
+                .unwrap()
+                .iter()
+                .position(|&account_index| account_index == index_in_transaction)
+                .unwrap_or(ix_account_index) as IndexOfAccount;
+            let index_in_transaction = index_in_transaction as usize;
+            InstructionAccount {
+                index_in_transaction: index_in_transaction as IndexOfAccount,
+                index_in_caller: index_in_transaction as IndexOfAccount,
+                index_in_callee,
+                is_signer: keys.is_signer(index_in_transaction),
+                is_writable: keys.is_writable(index_in_transaction),
+            }
+        })
+        .collect();
+
+    let transaction_accounts: Vec<TransactionAccount> = keys
+        .keys
+        .iter()
+        .map(|key| {
+            if *key == &instruction.program_id {
+                (**key, stub_out_program_account(loader_key))
+            } else {
+                let account = accounts
+                    .iter()
+                    .find(|(k, _)| k == *key)
+                    .map(|(_, account)| account.clone())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "    [mollusk]: An account required by the instruction was not \
+                             provided: {:?}",
+                            key,
+                        )
+                    });
+                (**key, account)
+            }
+        })
+        .collect();
+
+    CompiledAccounts {
+        program_id_index: compiled_instruction.program_id_index as u16,
+        instruction_accounts,
+        transaction_accounts,
+    }
+}
+
+fn stub_out_program_account(loader_key: Pubkey) -> AccountSharedData {
+    let mut program_account = AccountSharedData::default();
+    program_account.set_owner(loader_key);
+    program_account.set_executable(true);
+    program_account
+}

--- a/harness/src/program.rs
+++ b/harness/src/program.rs
@@ -42,6 +42,13 @@ impl ProgramCache {
         &self.cache
     }
 
+    /// Add a builtin program to the cache.
+    pub fn add_builtin(&mut self, builtin: Builtin) {
+        let program_id = builtin.program_id;
+        let entry = builtin.program_cache_entry();
+        self.cache.write().unwrap().replenish(program_id, entry);
+    }
+
     /// Add a program to the cache.
     pub fn add_program(
         &mut self,
@@ -72,11 +79,9 @@ impl ProgramCache {
         );
     }
 
-    /// Add a builtin program to the cache.
-    pub fn add_builtin(&mut self, builtin: Builtin) {
-        let program_id = builtin.program_id;
-        let entry = builtin.program_cache_entry();
-        self.cache.write().unwrap().replenish(program_id, entry);
+    /// Load a program from the cache.
+    pub fn load_program(&self, program_id: &Pubkey) -> Option<Arc<ProgramCacheEntry>> {
+        self.cache.read().unwrap().find(program_id)
     }
 }
 

--- a/harness/tests/bpf_program.rs
+++ b/harness/tests/bpf_program.rs
@@ -254,18 +254,6 @@ fn test_cpi() {
         )
     };
 
-    // Fail CPI target program account not provided.
-    {
-        mollusk.process_and_validate_instruction(
-            &instruction,
-            &[(key, account.clone())],
-            &[
-                Check::err(ProgramError::NotEnoughAccountKeys),
-                Check::compute_units(0), // No compute units used.
-            ],
-        );
-    }
-
     // Fail CPI target program not added to test environment.
     {
         mollusk.process_and_validate_instruction(


### PR DESCRIPTION
#### Problem
Currently, if the same account is used twice in an instruction, and twice in the accounts list, Mollusk will not unify the roles of the accounts. For example, consider the following instruction:

```
1. [ writable ] Account 1
2. [  signer  ] Account 2
```

If the same key was provided for both accounts 1 & 2, they would be serialized into the VM as separate accounts with the following roles:

```
{
    account_1: { is_signer: false, is_writable: true }
    account_2: { is_signer: true, is_writable: false }
}
```

Instead they should both be writable and both be signer.

#### Summary of Changes
Partially reimplement the transaction compilation used in [`Message::new_with_blockhash`](https://github.com/anza-xyz/agave/blob/c6e8239843af8e6301cd198e39d0a44add427bef/sdk/program/src/message/legacy.rs#L357) to build out the transaction context for Mollusk invokes.