### PR TITLE
[2.0] feat: harness: api to process fixtures

### DIFF
--- a/harness/src/fuzz/firedancer.rs
+++ b/harness/src/fuzz/firedancer.rs
@@ -8,6 +8,7 @@ use {
     crate::{
         accounts::{compile_accounts, CompiledAccounts},
         result::{Check, InstructionResult},
+        sysvar::Sysvars,
         Mollusk, DEFAULT_LOADER_KEY,
     },
     mollusk_svm_fuzz_fixture_firedancer::{
@@ -19,9 +20,10 @@ use {
         metadata::Metadata as FuzzMetadata,
         Fixture as FuzzFixture,
     },
+    solana_compute_budget::compute_budget::ComputeBudget,
     solana_sdk::{
         account::AccountSharedData,
-        instruction::{Instruction, InstructionError},
+        instruction::{AccountMeta, Instruction, InstructionError},
         pubkey::Pubkey,
     },
 };
@@ -52,6 +54,16 @@ static BUILTIN_PROGRAM_IDS: &[Pubkey] = &[
 fn instr_err_to_num(error: &InstructionError) -> i32 {
     let serialized_err = bincode::serialize(error).unwrap();
     i32::from_le_bytes((&serialized_err[0..4]).try_into().unwrap()) + 1
+}
+
+fn num_to_instr_err(num: i32, custom_code: u32) -> InstructionError {
+    let val = (num - 1) as u64;
+    let le = val.to_le_bytes();
+    let mut deser = bincode::deserialize(&le).unwrap();
+    if custom_code != 0 && matches!(deser, InstructionError::Custom(_)) {
+        deser = InstructionError::Custom(custom_code);
+    }
+    deser
 }
 
 fn build_fixture_context(
@@ -98,6 +110,56 @@ fn build_fixture_context(
     }
 }
 
+fn parse_fixture_context(
+    context: &FuzzContext,
+) -> (Mollusk, Instruction, Vec<(Pubkey, AccountSharedData)>) {
+    let FuzzContext {
+        program_id,
+        accounts,
+        instruction_accounts,
+        instruction_data,
+        compute_units_available,
+        epoch_context,
+        ..
+    } = context;
+
+    let compute_budget = ComputeBudget {
+        compute_unit_limit: *compute_units_available,
+        ..Default::default()
+    };
+
+    let accounts = accounts
+        .iter()
+        .map(|(key, acct, _)| (*key, acct.clone()))
+        .collect::<Vec<_>>();
+
+    let mollusk = Mollusk {
+        compute_budget,
+        feature_set: epoch_context.feature_set.clone(),
+        sysvars: Sysvars::fill_from_accounts(&accounts),
+        ..Default::default()
+    };
+
+    let metas = instruction_accounts
+        .iter()
+        .map(|ia| {
+            let pubkey = accounts
+                .get(ia.index_in_caller as usize)
+                .expect("Index out of bounds")
+                .0;
+            AccountMeta {
+                pubkey,
+                is_signer: ia.is_signer,
+                is_writable: ia.is_writable,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let instruction = Instruction::new_with_bytes(*program_id, instruction_data, metas);
+
+    (mollusk, instruction, accounts)
+}
+
 fn build_fixture_effects(context: &FuzzContext, result: &InstructionResult) -> FuzzEffects {
     let mut program_custom_code = 0;
     let program_result = match &result.raw_result {
@@ -136,6 +198,47 @@ fn build_fixture_effects(context: &FuzzContext, result: &InstructionResult) -> F
     }
 }
 
+fn parse_fixture_effects(
+    mollusk: &Mollusk,
+    accounts: &[(Pubkey, AccountSharedData)],
+    effects: &FuzzEffects,
+) -> InstructionResult {
+    let raw_result = if effects.program_result == 0 {
+        Ok(())
+    } else {
+        Err(num_to_instr_err(
+            effects.program_result,
+            effects.program_custom_code,
+        ))
+    };
+
+    let program_result = raw_result.clone().into();
+
+    let resulting_accounts = accounts
+        .iter()
+        .map(|(key, acct)| {
+            let resulting_account = effects
+                .modified_accounts
+                .iter()
+                .find(|(k, _, _)| k == key)
+                .map(|(_, acct, _)| acct.clone())
+                .unwrap_or_else(|| acct.clone());
+            (*key, resulting_account)
+        })
+        .collect();
+
+    InstructionResult {
+        program_result,
+        raw_result,
+        execution_time: 0, // TODO: Omitted for now.
+        compute_units_consumed: mollusk
+            .compute_budget
+            .compute_unit_limit
+            .saturating_sub(effects.compute_units_available),
+        resulting_accounts,
+    }
+}
+
 fn instruction_metadata() -> FuzzMetadata {
     FuzzMetadata {
         // Mollusk is always an instruction harness.
@@ -159,4 +262,51 @@ pub fn build_fixture_from_mollusk_test(
         input,
         output,
     }
+}
+
+pub fn load_firedancer_fixture(
+    fixture: &mollusk_svm_fuzz_fixture_firedancer::Fixture,
+) -> (
+    Mollusk,
+    Instruction,
+    Vec<(Pubkey, AccountSharedData)>,
+    InstructionResult,
+) {
+    let (mollusk, instruction, accounts) = parse_fixture_context(&fixture.input);
+    let result = parse_fixture_effects(&mollusk, &accounts, &fixture.output);
+    (mollusk, instruction, accounts, result)
+}
+
+#[test]
+fn test_num_to_instr_err() {
+    [
+        InstructionError::InvalidArgument,
+        InstructionError::InvalidInstructionData,
+        InstructionError::InvalidAccountData,
+        InstructionError::AccountDataTooSmall,
+        InstructionError::InsufficientFunds,
+        InstructionError::IncorrectProgramId,
+        InstructionError::MissingRequiredSignature,
+        InstructionError::AccountAlreadyInitialized,
+        InstructionError::UninitializedAccount,
+        InstructionError::UnbalancedInstruction,
+        InstructionError::ModifiedProgramId,
+        InstructionError::Custom(0),
+        InstructionError::Custom(1),
+        InstructionError::Custom(2),
+        InstructionError::Custom(5),
+        InstructionError::Custom(400),
+        InstructionError::Custom(600),
+        InstructionError::Custom(1_000),
+    ]
+    .into_iter()
+    .for_each(|ie| {
+        let mut custom_code = 0;
+        if let InstructionError::Custom(c) = &ie {
+            custom_code = *c;
+        }
+        let result = instr_err_to_num(&ie);
+        let err = num_to_instr_err(result, custom_code);
+        assert_eq!(ie, err);
+    })
 }

--- a/harness/src/fuzz/mod.rs
+++ b/harness/src/fuzz/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "fuzz-fd")]
-mod firedancer;
+pub mod firedancer;
 #[cfg(feature = "fuzz")]
-mod mollusk;
+pub mod mollusk;
 
 use {
     crate::{

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -187,18 +187,15 @@ impl Mollusk {
             )
         };
 
-        let resulting_accounts: Vec<(Pubkey, AccountSharedData)> = (0..transaction_context
-            .get_number_of_accounts())
-            .filter_map(|index| {
-                let key = transaction_context
-                    .get_key_of_account_at_index(index)
-                    .unwrap();
-                let account = transaction_context.get_account_at_index(index).unwrap();
-                if *key != instruction.program_id {
-                    Some((*key, account.take()))
-                } else {
-                    None
-                }
+        let resulting_accounts: Vec<(Pubkey, AccountSharedData)> = accounts
+            .iter()
+            .filter_map(|(pubkey, _)| {
+                transaction_context
+                    .find_index_of_account(pubkey)
+                    .map(|index| {
+                        let account = transaction_context.get_account_at_index(index).unwrap();
+                        (*pubkey, account.take())
+                    })
             })
             .collect();
 
@@ -232,7 +229,23 @@ impl Mollusk {
         };
 
         for instruction in instructions {
-            result.absorb(self.process_instruction(instruction, &result.resulting_accounts));
+            let this_result = self.process_instruction(instruction, &result.resulting_accounts);
+
+            result.compute_units_consumed += this_result.compute_units_consumed;
+            result.execution_time += this_result.execution_time;
+            result.program_result = this_result.program_result;
+            for resulting_account in this_result.resulting_accounts.into_iter() {
+                if let Some(pos) = result
+                    .resulting_accounts
+                    .iter()
+                    .position(|(key, _)| key == &resulting_account.0)
+                {
+                    result.resulting_accounts[pos].1 = resulting_account.1;
+                } else {
+                    result.resulting_accounts.push(resulting_account);
+                }
+            }
+
             if result.program_result.is_err() {
                 break;
             }

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -294,4 +294,65 @@ impl Mollusk {
         result.run_checks(checks);
         result
     }
+
+    #[cfg(feature = "fuzz")]
+    /// Process a fuzz fixture using the minified Solana Virtual Machine (SVM)
+    /// environment.
+    ///
+    /// Fixtures provide an API to `decode` a raw blob, as well as read
+    /// fixtures from files. Those fixtures can then be provided to this
+    /// function to process them and get a Mollusk result.
+    pub fn process_fixture(fixture: &mollusk_svm_fuzz_fixture::Fixture) -> InstructionResult {
+        let (mollusk, instruction, accounts, _) = fuzz::mollusk::load_fixture(fixture);
+        mollusk.process_instruction(&instruction, &accounts)
+    }
+
+    #[cfg(feature = "fuzz")]
+    /// Process a fuzz fixture using the minified Solana Virtual Machine (SVM)
+    /// environment and compare the result against the fixture's effects.
+    ///
+    /// Fixtures provide an API to `decode` a raw blob, as well as read
+    /// fixtures from files. Those fixtures can then be provided to this
+    /// function to process them and get a Mollusk result.
+    pub fn process_and_validate_fixture(
+        fixture: &mollusk_svm_fuzz_fixture::Fixture,
+    ) -> InstructionResult {
+        let (mollusk, instruction, accounts, result) = fuzz::mollusk::load_fixture(fixture);
+        let this_result = mollusk.process_instruction(&instruction, &accounts);
+        result.compare(&this_result);
+        this_result
+    }
+
+    #[cfg(feature = "fuzz-fd")]
+    /// Process a Firedancer fuzz fixture using the minified Solana Virtual
+    /// Machine (SVM) environment.
+    ///
+    /// Fixtures provide an API to `decode` a raw blob, as well as read
+    /// fixtures from files. Those fixtures can then be provided to this
+    /// function to process them and get a Mollusk result.
+    pub fn process_firedancer_fixture(
+        fixture: &mollusk_svm_fuzz_fixture_firedancer::Fixture,
+    ) -> InstructionResult {
+        let (mollusk, instruction, accounts, _) =
+            fuzz::firedancer::load_firedancer_fixture(fixture);
+        mollusk.process_instruction(&instruction, &accounts)
+    }
+
+    #[cfg(feature = "fuzz-fd")]
+    /// Process a Firedancer fuzz fixture using the minified Solana Virtual
+    /// Machine (SVM) environment and compare the result against the
+    /// fixture's effects.
+    ///
+    /// Fixtures provide an API to `decode` a raw blob, as well as read
+    /// fixtures from files. Those fixtures can then be provided to this
+    /// function to process them and get a Mollusk result.
+    pub fn process_and_validate_firedancer_fixture(
+        fixture: &mollusk_svm_fuzz_fixture_firedancer::Fixture,
+    ) -> InstructionResult {
+        let (mollusk, instruction, accounts, result) =
+            fuzz::firedancer::load_firedancer_fixture(fixture);
+        let this_result = mollusk.process_instruction(&instruction, &accounts);
+        result.compare(&this_result);
+        this_result
+    }
 }

--- a/harness/src/result.rs
+++ b/harness/src/result.rs
@@ -192,6 +192,38 @@ impl InstructionResult {
             }
         }
     }
+
+    /// Compare an `InstructionResult` against another `InstructionResult`,
+    /// panicking on any mismatches.
+    pub fn compare(&self, b: &Self) {
+        assert_eq!(
+            self.compute_units_consumed, b.compute_units_consumed,
+            "compute units consumed mismatch"
+        );
+        // TODO: Omitted for now.
+        // assert_eq!(
+        //     self.execution_time, b.execution_time,
+        //     "execution time mismatch"
+        // );
+        assert_eq!(
+            self.program_result, b.program_result,
+            "program result mismatch"
+        );
+        assert_eq!(self.raw_result, b.raw_result, "raw result mismatch");
+        assert_eq!(
+            self.resulting_accounts.len(),
+            b.resulting_accounts.len(),
+            "resulting accounts length mismatch"
+        );
+        for (a, b) in self
+            .resulting_accounts
+            .iter()
+            .zip(b.resulting_accounts.iter())
+        {
+            assert_eq!(a.0, b.0, "resulting account pubkey mismatch");
+            assert_eq!(a.1, b.1, "resulting account data mismatch");
+        }
+    }
 }
 
 enum CheckType<'a> {

--- a/harness/src/result.rs
+++ b/harness/src/result.rs
@@ -80,22 +80,6 @@ impl InstructionResult {
             .map(|(_, a)| a)
     }
 
-    /// Absorb another `InstructionResult` into this one.
-    pub(crate) fn absorb(&mut self, other: Self) {
-        self.compute_units_consumed += other.compute_units_consumed;
-        self.execution_time += other.execution_time;
-        self.program_result = other.program_result;
-        for (key, account) in other.resulting_accounts {
-            if let Some((_, existing_account)) =
-                self.resulting_accounts.iter_mut().find(|(k, _)| k == &key)
-            {
-                *existing_account = account;
-            } else {
-                self.resulting_accounts.push((key, account));
-            }
-        }
-    }
-
     /// Perform checks on the instruction result, panicking if any checks fail.
     pub(crate) fn run_checks(&self, checks: &[Check]) {
         for check in checks {

--- a/harness/src/sysvar.rs
+++ b/harness/src/sysvar.rs
@@ -3,7 +3,7 @@
 use {
     solana_program_runtime::sysvar_cache::SysvarCache,
     solana_sdk::{
-        account::AccountSharedData,
+        account::{AccountSharedData, ReadableAccount},
         clock::{Clock, Slot},
         epoch_rewards::EpochRewards,
         epoch_schedule::EpochSchedule,
@@ -59,6 +59,36 @@ impl Default for Sysvars {
 }
 
 impl Sysvars {
+    /// Create a `Sysvars` instance from a list of accounts. Any missing
+    /// sysvars will be filled with default values.
+    pub fn fill_from_accounts(accounts: &[(Pubkey, AccountSharedData)]) -> Self {
+        let mut me = Self::default();
+        for (key, account) in accounts {
+            if key == &Clock::id() {
+                me.clock = bincode::deserialize(account.data()).unwrap();
+            }
+            if key == &EpochRewards::id() {
+                me.epoch_rewards = bincode::deserialize(account.data()).unwrap();
+            }
+            if key == &EpochSchedule::id() {
+                me.epoch_schedule = bincode::deserialize(account.data()).unwrap();
+            }
+            if key == &LastRestartSlot::id() {
+                me.last_restart_slot = bincode::deserialize(account.data()).unwrap();
+            }
+            if key == &Rent::id() {
+                me.rent = bincode::deserialize(account.data()).unwrap();
+            }
+            if key == &SlotHashes::id() {
+                me.slot_hashes = bincode::deserialize(account.data()).unwrap();
+            }
+            if key == &StakeHistory::id() {
+                me.stake_history = bincode::deserialize(account.data()).unwrap();
+            }
+        }
+        me
+    }
+
     fn sysvar_account<T: SysvarId + Sysvar>(&self, sysvar: &T) -> (Pubkey, AccountSharedData) {
         let data = bincode::serialize::<T>(sysvar).unwrap();
         let space = data.len();

--- a/harness/tests/process_fixture.rs
+++ b/harness/tests/process_fixture.rs
@@ -1,0 +1,110 @@
+#![cfg(any(feature = "fuzz", feature = "fuzz-fd"))]
+
+use {
+    mollusk_svm::Mollusk,
+    solana_sdk::{account::AccountSharedData, pubkey::Pubkey, system_instruction, system_program},
+};
+
+const BASE_LAMPORTS: u64 = 100_000_000;
+
+#[cfg(feature = "fuzz")]
+#[test]
+fn test_process_mollusk() {
+    let ok_transfer_amount = 42_000;
+    let too_much = BASE_LAMPORTS + 1;
+
+    let mollusk = Mollusk::default();
+
+    let sender = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+
+    let accounts = vec![
+        (
+            sender,
+            AccountSharedData::new(BASE_LAMPORTS, 0, &system_program::id()),
+        ),
+        (
+            recipient,
+            AccountSharedData::new(BASE_LAMPORTS, 0, &system_program::id()),
+        ),
+    ];
+
+    // First try the success case.
+    let instruction = system_instruction::transfer(&sender, &recipient, ok_transfer_amount);
+    let result = mollusk.process_instruction(&instruction, &accounts);
+
+    let fixture = mollusk_svm::fuzz::mollusk::build_fixture_from_mollusk_test(
+        &mollusk,
+        &instruction,
+        &accounts,
+        &result,
+        &[],
+    );
+
+    Mollusk::process_and_validate_fixture(&fixture);
+
+    // Now the error case.
+    let instruction = system_instruction::transfer(&sender, &recipient, too_much);
+    let result = mollusk.process_instruction(&instruction, &accounts);
+
+    let fixture = mollusk_svm::fuzz::mollusk::build_fixture_from_mollusk_test(
+        &mollusk,
+        &instruction,
+        &accounts,
+        &result,
+        &[],
+    );
+
+    Mollusk::process_and_validate_fixture(&fixture);
+}
+
+#[cfg(feature = "fuzz-fd")]
+#[test]
+fn test_process_firedancer() {
+    let ok_transfer_amount = 42_000;
+    let too_much = BASE_LAMPORTS + 1;
+
+    let mollusk = Mollusk::default();
+
+    let sender = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+
+    let accounts = vec![
+        (
+            sender,
+            AccountSharedData::new(BASE_LAMPORTS, 0, &system_program::id()),
+        ),
+        (
+            recipient,
+            AccountSharedData::new(BASE_LAMPORTS, 0, &system_program::id()),
+        ),
+    ];
+
+    // First try the success case.
+    let instruction = system_instruction::transfer(&sender, &recipient, ok_transfer_amount);
+    let result = mollusk.process_instruction(&instruction, &accounts);
+
+    let fixture = mollusk_svm::fuzz::firedancer::build_fixture_from_mollusk_test(
+        &mollusk,
+        &instruction,
+        &accounts,
+        &result,
+        &[],
+    );
+
+    Mollusk::process_and_validate_firedancer_fixture(&fixture);
+
+    // Now the error case.
+    let instruction = system_instruction::transfer(&sender, &recipient, too_much);
+    let result = mollusk.process_instruction(&instruction, &accounts);
+
+    let fixture = mollusk_svm::fuzz::firedancer::build_fixture_from_mollusk_test(
+        &mollusk,
+        &instruction,
+        &accounts,
+        &result,
+        &[],
+    );
+
+    Mollusk::process_and_validate_firedancer_fixture(&fixture);
+}


### PR DESCRIPTION
This PR gives Mollusk the ability to process fuzz fixtures directly from a provided fixture.

Previously Mollusk could only generate fixtures, but now it can accept them and process them against its own harness.

Note: Requires either the `fuzz` or `fuzz-fd` feature.