### PR TITLE
create EpochSchedule without warmup

### DIFF
--- a/harness/src/sysvar.rs
+++ b/harness/src/sysvar.rs
@@ -33,7 +33,7 @@ impl Default for Sysvars {
     fn default() -> Self {
         let clock = Clock::default();
         let epoch_rewards = EpochRewards::default();
-        let epoch_schedule = EpochSchedule::default();
+        let epoch_schedule = EpochSchedule::without_warmup();
         let last_restart_slot = LastRestartSlot::default();
         let rent = Rent::default();
 


### PR DESCRIPTION
`EpochSchedule::default()` sets a warmup period, which means you need to do things to figure out what the first normal slot and epoch are. by using `EpochSchedule::without_warmup()` instead, the first normal slot and epoch are both 0. this makes typical usage easier. tests that want to see a warmup can override `EpochSchedule` explicitly