### PR TITLE
init stake history with epoch

### DIFF
--- a/harness/src/sysvar.rs
+++ b/harness/src/sysvar.rs
@@ -44,7 +44,7 @@ impl Default for Sysvars {
         };
 
         let mut stake_history = StakeHistory::default();
-        stake_history.add(clock.slot, StakeHistoryEntry::default());
+        stake_history.add(clock.epoch, StakeHistoryEntry::default());
 
         Self {
             clock,


### PR DESCRIPTION
stake history is segmented by epoch rather than slot. this works because by default both are 0, but isnt correct