### PR TITLE
override sysvars from accounts list

### DIFF
--- a/harness/src/fuzz/firedancer.rs
+++ b/harness/src/fuzz/firedancer.rs
@@ -133,10 +133,13 @@ fn parse_fixture_context(
         .map(|(key, acct, _)| (*key, acct.clone()))
         .collect::<Vec<_>>();
 
+    let mut sysvars = Sysvars::default();
+    sysvars.fill_from_accounts(&accounts);
+
     let mollusk = Mollusk {
         compute_budget,
         feature_set: epoch_context.feature_set.clone(),
-        sysvars: Sysvars::fill_from_accounts(&accounts),
+        sysvars,
         ..Default::default()
     };
 

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -155,6 +155,9 @@ impl Mollusk {
         let mut compute_units_consumed = 0;
         let mut timings = ExecuteTimings::default();
 
+        let mut sysvars = self.sysvars.clone();
+        sysvars.fill_from_accounts(accounts);
+
         let loader_key = self
             .program_cache
             .load_program(&instruction.program_id)
@@ -169,7 +172,7 @@ impl Mollusk {
 
         let mut transaction_context = TransactionContext::new(
             transaction_accounts,
-            self.sysvars.rent.clone(),
+            sysvars.rent.clone(),
             self.compute_budget.max_instruction_stack_depth,
             self.compute_budget.max_instruction_trace_length,
         );
@@ -185,7 +188,7 @@ impl Mollusk {
                     None,
                     Arc::new(self.feature_set.clone()),
                     self.fee_structure.lamports_per_signature,
-                    &SysvarCache::from(&self.sysvars),
+                    &SysvarCache::from(&sysvars),
                 ),
                 None,
                 self.compute_budget,

--- a/harness/src/sysvar.rs
+++ b/harness/src/sysvar.rs
@@ -59,34 +59,32 @@ impl Default for Sysvars {
 }
 
 impl Sysvars {
-    /// Create a `Sysvars` instance from a list of accounts. Any missing
-    /// sysvars will be filled with default values.
-    pub fn fill_from_accounts(accounts: &[(Pubkey, AccountSharedData)]) -> Self {
-        let mut me = Self::default();
+    /// Update a `Sysvars` instance from a list of accounts. Any sysvars not
+    /// in the account list will retain their existing values.
+    pub fn fill_from_accounts(&mut self, accounts: &[(Pubkey, AccountSharedData)]) {
         for (key, account) in accounts {
             if key == &Clock::id() {
-                me.clock = bincode::deserialize(account.data()).unwrap();
+                self.clock = bincode::deserialize(account.data()).unwrap();
             }
             if key == &EpochRewards::id() {
-                me.epoch_rewards = bincode::deserialize(account.data()).unwrap();
+                self.epoch_rewards = bincode::deserialize(account.data()).unwrap();
             }
             if key == &EpochSchedule::id() {
-                me.epoch_schedule = bincode::deserialize(account.data()).unwrap();
+                self.epoch_schedule = bincode::deserialize(account.data()).unwrap();
             }
             if key == &LastRestartSlot::id() {
-                me.last_restart_slot = bincode::deserialize(account.data()).unwrap();
+                self.last_restart_slot = bincode::deserialize(account.data()).unwrap();
             }
             if key == &Rent::id() {
-                me.rent = bincode::deserialize(account.data()).unwrap();
+                self.rent = bincode::deserialize(account.data()).unwrap();
             }
             if key == &SlotHashes::id() {
-                me.slot_hashes = bincode::deserialize(account.data()).unwrap();
+                self.slot_hashes = bincode::deserialize(account.data()).unwrap();
             }
             if key == &StakeHistory::id() {
-                me.stake_history = bincode::deserialize(account.data()).unwrap();
+                self.stake_history = bincode::deserialize(account.data()).unwrap();
             }
         }
-        me
     }
 
     fn sysvar_account<T: SysvarId + Sysvar>(&self, sysvar: &T) -> (Pubkey, AccountSharedData) {

--- a/harness/src/sysvar.rs
+++ b/harness/src/sysvar.rs
@@ -29,6 +29,20 @@ pub struct Sysvars {
     pub stake_history: StakeHistory,
 }
 
+impl Clone for Sysvars {
+    fn clone(&self) -> Self {
+        Self {
+            clock: self.clock.clone(),
+            epoch_rewards: self.epoch_rewards.clone(),
+            epoch_schedule: self.epoch_schedule.clone(),
+            last_restart_slot: self.last_restart_slot.clone(),
+            rent: self.rent.clone(),
+            slot_hashes: SlotHashes::new(&self.slot_hashes),
+            stake_history: self.stake_history.clone(),
+        }
+    }
+}
+
 impl Default for Sysvars {
     fn default() -> Self {
         let clock = Clock::default();


### PR DESCRIPTION
this is a convenience to make porting stake_instruction.rs tests (and other similar `InvokeContext`-based tests) much simpler. sysvars from the accounts list are used to override the sysvars on `Mollusk`, without mutating it. this is to accord with the way existing tests are structured, so we dont need to add any setup logic that doesnt already exist. in general they create sysvar states and pass them into `InvokeContext` via `process_instruction` directly 

i considered letting it mutate `Sysvars` but this seems cleaner, especially since we will be able to remove it someday when the bpf programs use sysvar syscalls and dont need to accept sysvar accounts at all