### PR TITLE
harness: rework sysvar caching

### DIFF
--- a/harness/src/fuzz/firedancer.rs
+++ b/harness/src/fuzz/firedancer.rs
@@ -8,7 +8,6 @@ use {
     crate::{
         accounts::{compile_accounts, CompiledAccounts},
         result::{Check, InstructionResult},
-        sysvar::Sysvars,
         Mollusk, DEFAULT_LOADER_KEY,
     },
     mollusk_svm_fuzz_fixture_firedancer::{
@@ -136,7 +135,6 @@ fn parse_fixture_context(
     let mollusk = Mollusk {
         compute_budget,
         feature_set: epoch_context.feature_set.clone(),
-        sysvars: Sysvars::fill_from_accounts(&accounts),
         ..Default::default()
     };
 

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -44,10 +44,7 @@ use {
     accounts::CompiledAccounts,
     mollusk_svm_error::error::{MolluskError, MolluskPanic},
     solana_compute_budget::compute_budget::ComputeBudget,
-    solana_program_runtime::{
-        invoke_context::{EnvironmentConfig, InvokeContext},
-        sysvar_cache::SysvarCache,
-    },
+    solana_program_runtime::invoke_context::{EnvironmentConfig, InvokeContext},
     solana_sdk::{
         account::AccountSharedData, bpf_loader_upgradeable, feature_set::FeatureSet,
         fee::FeeStructure, hash::Hash, instruction::Instruction, pubkey::Pubkey,
@@ -175,17 +172,18 @@ impl Mollusk {
         );
 
         let invoke_result = {
-            let mut cache = self.program_cache.cache().write().unwrap();
+            let mut program_cache = self.program_cache.cache().write().unwrap();
+            let sysvar_cache = self.sysvars.setup_sysvar_cache(accounts);
             InvokeContext::new(
                 &mut transaction_context,
-                &mut cache,
+                &mut program_cache,
                 EnvironmentConfig::new(
                     Hash::default(),
                     None,
                     None,
                     Arc::new(self.feature_set.clone()),
                     self.fee_structure.lamports_per_signature,
-                    &SysvarCache::from(&self.sysvars),
+                    &sysvar_cache,
                 ),
                 None,
                 self.compute_budget,


### PR DESCRIPTION
This PR reworks the way Mollusk creates a sysvar cache for instruction processing.

After this change, the harness will create a new sysvar cache based first on the provided accounts and then on the default values contained in the `Sysvars` object.

This allows fuzz fixtures to provide invalid sysvar account data and see the proper errors in their program's execution as a result.

cc @2501babe 