### PR TITLE
fuzz: refactor fixture processing harnesses to use `&mut self`

### DIFF
--- a/harness/src/fuzz/check.rs
+++ b/harness/src/fuzz/check.rs
@@ -1,0 +1,173 @@
+//! Checks to run against a fixture when validating.
+
+use {
+    crate::result::{Check, InstructionResult},
+    solana_sdk::{
+        account::{Account, ReadableAccount},
+        pubkey::Pubkey,
+    },
+};
+
+/// Checks to run against a fixture when validating.
+///
+/// Similar to Mollusk's `result::Check`, this allows a developer to dictate
+/// the type of checks to run on the fixture's effects.
+///
+/// Keep in mind that validation of fixtures works slightly differently than
+/// typical Mollusk unit tests. In a Mollusk test, you can provide the value to
+/// compare a portion of the result against (ie. compute units). However, when
+/// comparing the result of a Mollusk invocation against a fixture, the value
+/// from the fixture itself is used.
+///
+/// For that reason, these are unary variants, and do not offer the developer a
+/// way to provide values to check against.
+pub enum FixtureCheck {
+    /// Validate compute units consumed.
+    ComputeUnits,
+    /// Validate the program result.
+    ProgramResult,
+    /// Validate the return data.
+    ReturnData,
+    /// Validate all resulting accounts.
+    AllResultingAccounts {
+        /// Whether or not to validate each account's data.
+        data: bool,
+        /// Whether or not to validate each account's lamports.
+        lamports: bool,
+        /// Whether or not to validate each account's owner.
+        owner: bool,
+        /// Whether or not to validate each account's space.
+        space: bool,
+    },
+    /// Validate the resulting accounts at certain addresses.
+    OnlyResultingAccounts {
+        /// The addresses on which to apply the validation.
+        addresses: Vec<Pubkey>,
+        /// Whether or not to validate each account's data.
+        data: bool,
+        /// Whether or not to validate each account's lamports.
+        lamports: bool,
+        /// Whether or not to validate each account's owner.
+        owner: bool,
+        /// Whether or not to validate each account's space.
+        space: bool,
+    },
+    /// Validate all of the resulting accounts _except_ the provided addresses.
+    AllResultingAccountsExcept {
+        /// The addresses on which to _not_ apply the validation.
+        ignore_addresses: Vec<Pubkey>,
+        /// On non-ignored accounts, whether or not to validate each account's
+        /// data.
+        data: bool,
+        /// On non-ignored accounts, whether or not to validate each account's
+        /// lamports.
+        lamports: bool,
+        /// On non-ignored accounts, whether or not to validate each account's
+        /// owner.
+        owner: bool,
+        /// On non-ignored accounts, whether or not to validate each account's
+        /// space.
+        space: bool,
+    },
+}
+
+fn add_account_checks<'a>(
+    checks: &mut Vec<Check<'a>>,
+    accounts: impl Iterator<Item = &'a (Pubkey, Account)>,
+    data: bool,
+    lamports: bool,
+    owner: bool,
+    space: bool,
+) {
+    for (pubkey, account) in accounts {
+        let mut builder = Check::account(pubkey);
+        if data {
+            builder = builder.data(account.data());
+        }
+        if lamports {
+            builder = builder.lamports(account.lamports());
+        }
+        if owner {
+            builder = builder.owner(account.owner());
+        }
+        if space {
+            builder = builder.space(account.data().len());
+        }
+        checks.push(builder.build());
+    }
+}
+
+pub(crate) fn evaluate_results_with_fixture_checks(
+    expected: &InstructionResult,
+    result: &InstructionResult,
+    fixture_checks: &[FixtureCheck],
+) {
+    let mut checks = vec![];
+
+    for fixture_check in fixture_checks {
+        match fixture_check {
+            FixtureCheck::ComputeUnits => {
+                checks.push(Check::compute_units(expected.compute_units_consumed))
+            }
+            FixtureCheck::ProgramResult => {
+                checks.push(Check::program_result(expected.program_result.clone()))
+            }
+            FixtureCheck::ReturnData => checks.push(Check::return_data(&expected.return_data)),
+            FixtureCheck::AllResultingAccounts {
+                data,
+                lamports,
+                owner,
+                space,
+            } => {
+                add_account_checks(
+                    &mut checks,
+                    expected.resulting_accounts.iter(),
+                    *data,
+                    *lamports,
+                    *owner,
+                    *space,
+                );
+            }
+            FixtureCheck::OnlyResultingAccounts {
+                addresses,
+                data,
+                lamports,
+                owner,
+                space,
+            } => {
+                add_account_checks(
+                    &mut checks,
+                    expected
+                        .resulting_accounts
+                        .iter()
+                        .filter(|(pubkey, _)| addresses.contains(pubkey)),
+                    *data,
+                    *lamports,
+                    *owner,
+                    *space,
+                );
+            }
+            FixtureCheck::AllResultingAccountsExcept {
+                ignore_addresses,
+                data,
+                lamports,
+                owner,
+                space,
+            } => {
+                add_account_checks(
+                    &mut checks,
+                    expected
+                        .resulting_accounts
+                        .iter()
+                        .filter(|(pubkey, _)| !ignore_addresses.contains(pubkey)),
+                    *data,
+                    *lamports,
+                    *owner,
+                    *space,
+                );
+            }
+        }
+    }
+
+    result.run_checks(&checks);
+}

--- a/harness/src/fuzz/check.rs
+++ b/harness/src/fuzz/check.rs
@@ -71,6 +71,51 @@ pub enum FixtureCheck {
     },
 }
 
+impl FixtureCheck {
+    /// Validate all possible checks for all resulting accounts.
+    ///
+    /// Note: To omit certain checks, use the variant directly, ie.
+    /// `FixtureCheck::AllResultingAccounts { data: false, .. }`.
+    pub fn all_resulting_accounts() -> Self {
+        Self::AllResultingAccounts {
+            data: true,
+            lamports: true,
+            owner: true,
+            space: true,
+        }
+    }
+
+    /// Validate all possible checks for only the resulting accounts at certain
+    /// addresses.
+    ///
+    /// Note: To omit certain checks, use the variant directly, ie.
+    /// `FixtureCheck::OnlyResultingAccounts { data: false, .. }`.
+    pub fn only_resulting_accounts(addresses: &[Pubkey]) -> Self {
+        Self::OnlyResultingAccounts {
+            addresses: addresses.to_vec(),
+            data: true,
+            lamports: true,
+            owner: true,
+            space: true,
+        }
+    }
+
+    /// Validate all possible checks for all of the resulting accounts _except_
+    /// the provided addresses.
+    ///
+    /// Note: To omit certain checks, use the variant directly, ie.
+    /// `FixtureCheck::AllResultingAccountsExcept { data: false, .. }`.
+    pub fn all_resulting_accounts_except(ignore_addresses: &[Pubkey]) -> Self {
+        Self::AllResultingAccountsExcept {
+            ignore_addresses: ignore_addresses.to_vec(),
+            data: true,
+            lamports: true,
+            owner: true,
+            space: true,
+        }
+    }
+}
+
 fn add_account_checks<'a>(
     checks: &mut Vec<Check<'a>>,
     accounts: impl Iterator<Item = &'a (Pubkey, Account)>,

--- a/harness/src/fuzz/firedancer.rs
+++ b/harness/src/fuzz/firedancer.rs
@@ -7,7 +7,7 @@
 use {
     crate::{
         accounts::{compile_accounts, CompiledAccounts},
-        result::{Check, InstructionResult},
+        result::InstructionResult,
         Mollusk, DEFAULT_LOADER_KEY,
     },
     mollusk_svm_fuzz_fixture_firedancer::{
@@ -250,7 +250,6 @@ pub fn build_fixture_from_mollusk_test(
     instruction: &Instruction,
     accounts: &[(Pubkey, Account)],
     result: &InstructionResult,
-    _checks: &[Check],
 ) -> FuzzFixture {
     let input = build_fixture_context(
         accounts,

--- a/harness/src/fuzz/mod.rs
+++ b/harness/src/fuzz/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "fuzz", feature = "fuzz-fd"))]
+pub mod check;
 #[cfg(feature = "fuzz-fd")]
 pub mod firedancer;
 #[cfg(feature = "fuzz")]

--- a/harness/src/fuzz/mod.rs
+++ b/harness/src/fuzz/mod.rs
@@ -4,10 +4,7 @@ pub mod firedancer;
 pub mod mollusk;
 
 use {
-    crate::{
-        result::{Check, InstructionResult},
-        Mollusk,
-    },
+    crate::{result::InstructionResult, Mollusk},
     mollusk_svm_fuzz_fs::FsHandler,
     solana_sdk::{account::Account, instruction::Instruction, pubkey::Pubkey},
 };
@@ -17,20 +14,14 @@ pub fn generate_fixtures_from_mollusk_test(
     instruction: &Instruction,
     accounts: &[(Pubkey, Account)],
     result: &InstructionResult,
-    checks: &[Check],
 ) {
     #[cfg(feature = "fuzz")]
     {
         if std::env::var("EJECT_FUZZ_FIXTURES").is_ok()
             || std::env::var("EJECT_FUZZ_FIXTURES_JSON").is_ok()
         {
-            let fixture = mollusk::build_fixture_from_mollusk_test(
-                mollusk,
-                instruction,
-                accounts,
-                result,
-                checks,
-            );
+            let fixture =
+                mollusk::build_fixture_from_mollusk_test(mollusk, instruction, accounts, result);
             let handler = FsHandler::new(fixture);
             if let Ok(blob_dir) = std::env::var("EJECT_FUZZ_FIXTURES") {
                 handler.dump_to_blob_file(&blob_dir);
@@ -46,13 +37,8 @@ pub fn generate_fixtures_from_mollusk_test(
         if std::env::var("EJECT_FUZZ_FIXTURES_FD").is_ok()
             || std::env::var("EJECT_FUZZ_FIXTURES_JSON_FD").is_ok()
         {
-            let fixture = firedancer::build_fixture_from_mollusk_test(
-                mollusk,
-                instruction,
-                accounts,
-                result,
-                checks,
-            );
+            let fixture =
+                firedancer::build_fixture_from_mollusk_test(mollusk, instruction, accounts, result);
             let handler = FsHandler::new(fixture);
             if let Ok(blob_dir) = std::env::var("EJECT_FUZZ_FIXTURES_FD") {
                 handler.dump_to_blob_file(&blob_dir);

--- a/harness/src/fuzz/mollusk.rs
+++ b/harness/src/fuzz/mollusk.rs
@@ -6,7 +6,7 @@
 
 use {
     crate::{
-        result::{Check, InstructionResult, ProgramResult},
+        result::{InstructionResult, ProgramResult},
         sysvar::Sysvars,
         Mollusk,
     },
@@ -163,7 +163,6 @@ pub fn build_fixture_from_mollusk_test(
     instruction: &Instruction,
     accounts: &[(Pubkey, Account)],
     result: &InstructionResult,
-    _checks: &[Check],
 ) -> FuzzFixture {
     let input = build_fixture_context(
         accounts,

--- a/harness/src/fuzz/mollusk.rs
+++ b/harness/src/fuzz/mollusk.rs
@@ -14,8 +14,10 @@ use {
         context::Context as FuzzContext, effects::Effects as FuzzEffects,
         sysvars::Sysvars as FuzzSysvars, Fixture as FuzzFixture,
     },
+    solana_compute_budget::compute_budget::ComputeBudget,
     solana_sdk::{
         account::Account,
+        feature_set::FeatureSet,
         instruction::{Instruction, InstructionError},
         pubkey::Pubkey,
         slot_hashes::SlotHashes,
@@ -103,18 +105,21 @@ impl From<&FuzzEffects> for InstructionResult {
     }
 }
 
-fn build_fixture_context(
-    mollusk: &Mollusk,
-    instruction: &Instruction,
-    accounts: &[(Pubkey, Account)],
-) -> FuzzContext {
-    let Mollusk {
-        compute_budget,
-        feature_set,
-        sysvars,
-        ..
-    } = mollusk;
+pub struct ParsedFixtureContext {
+    pub accounts: Vec<(Pubkey, Account)>,
+    pub compute_budget: ComputeBudget,
+    pub feature_set: FeatureSet,
+    pub instruction: Instruction,
+    pub sysvars: Sysvars,
+}
 
+fn build_fixture_context(
+    accounts: &[(Pubkey, Account)],
+    compute_budget: &ComputeBudget,
+    feature_set: &FeatureSet,
+    instruction: &Instruction,
+    sysvars: &Sysvars,
+) -> FuzzContext {
     let instruction_accounts = instruction.accounts.clone();
     let instruction_data = instruction.data.clone();
     let accounts = accounts.to_vec();
@@ -130,7 +135,7 @@ fn build_fixture_context(
     }
 }
 
-fn parse_fixture_context(context: &FuzzContext) -> (Mollusk, Instruction, Vec<(Pubkey, Account)>) {
+pub(crate) fn parse_fixture_context(context: &FuzzContext) -> ParsedFixtureContext {
     let FuzzContext {
         compute_budget,
         feature_set,
@@ -141,19 +146,16 @@ fn parse_fixture_context(context: &FuzzContext) -> (Mollusk, Instruction, Vec<(P
         accounts,
     } = context;
 
-    let mollusk = Mollusk {
-        compute_budget: *compute_budget,
-        feature_set: feature_set.clone(),
-        sysvars: sysvars.into(),
-        ..Default::default()
-    };
-
     let instruction =
         Instruction::new_with_bytes(*program_id, instruction_data, instruction_accounts.clone());
 
-    let accounts = accounts.clone();
-
-    (mollusk, instruction, accounts)
+    ParsedFixtureContext {
+        accounts: accounts.clone(),
+        compute_budget: *compute_budget,
+        feature_set: feature_set.clone(),
+        instruction,
+        sysvars: sysvars.into(),
+    }
 }
 
 pub fn build_fixture_from_mollusk_test(
@@ -163,7 +165,13 @@ pub fn build_fixture_from_mollusk_test(
     result: &InstructionResult,
     _checks: &[Check],
 ) -> FuzzFixture {
-    let input = build_fixture_context(mollusk, instruction, accounts);
+    let input = build_fixture_context(
+        accounts,
+        &mollusk.compute_budget,
+        &mollusk.feature_set,
+        instruction,
+        &mollusk.sysvars,
+    );
     // This should probably be built from the checks, but there's currently no
     // mechanism to enforce full check coverage on a result.
     let output = FuzzEffects::from(result);
@@ -172,13 +180,9 @@ pub fn build_fixture_from_mollusk_test(
 
 pub fn load_fixture(
     fixture: &mollusk_svm_fuzz_fixture::Fixture,
-) -> (
-    Mollusk,
-    Instruction,
-    Vec<(Pubkey, Account)>,
-    InstructionResult,
-) {
-    let (mollusk, instruction, accounts) = parse_fixture_context(&fixture.input);
-    let result = InstructionResult::from(&fixture.output);
-    (mollusk, instruction, accounts, result)
+) -> (ParsedFixtureContext, InstructionResult) {
+    (
+        parse_fixture_context(&fixture.input),
+        InstructionResult::from(&fixture.output),
+    )
 }

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -320,7 +320,7 @@ impl Mollusk {
         let result = self.process_instruction(instruction, accounts);
 
         #[cfg(any(feature = "fuzz", feature = "fuzz-fd"))]
-        fuzz::generate_fixtures_from_mollusk_test(self, instruction, accounts, &result, checks);
+        fuzz::generate_fixtures_from_mollusk_test(self, instruction, accounts, &result);
 
         result.run_checks(checks);
         result

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -384,7 +384,18 @@ impl Mollusk {
     /// Fixtures provide an API to `decode` a raw blob, as well as read
     /// fixtures from files. Those fixtures can then be provided to this
     /// function to process them and get a Mollusk result.
-    pub fn process_fixture(fixture: &mollusk_svm_fuzz_fixture::Fixture) -> InstructionResult {
+    ///
+    /// Note: This is a mutable method on `Mollusk`, since loading a fixture
+    /// into the test environment will alter `Mollusk` values, such as compute
+    /// budget and sysvars. However, the program cache remains unchanged.
+    ///
+    /// Therefore, developers can provision a `Mollusk` instance, set up their
+    /// desired program cache, and then run a series of fixtures against that
+    /// `Mollusk` instance (and cache).
+    pub fn process_fixture(
+        &mut self,
+        fixture: &mollusk_svm_fuzz_fixture::Fixture,
+    ) -> InstructionResult {
         let (mollusk, instruction, accounts, _) = fuzz::mollusk::load_fixture(fixture);
         mollusk.process_instruction(&instruction, &accounts)
     }
@@ -396,7 +407,17 @@ impl Mollusk {
     /// Fixtures provide an API to `decode` a raw blob, as well as read
     /// fixtures from files. Those fixtures can then be provided to this
     /// function to process them and get a Mollusk result.
+    ///
+    ///
+    /// Note: This is a mutable method on `Mollusk`, since loading a fixture
+    /// into the test environment will alter `Mollusk` values, such as compute
+    /// budget and sysvars. However, the program cache remains unchanged.
+    ///
+    /// Therefore, developers can provision a `Mollusk` instance, set up their
+    /// desired program cache, and then run a series of fixtures against that
+    /// `Mollusk` instance (and cache).
     pub fn process_and_validate_fixture(
+        &mut self,
         fixture: &mollusk_svm_fuzz_fixture::Fixture,
     ) -> InstructionResult {
         let (mollusk, instruction, accounts, result) = fuzz::mollusk::load_fixture(fixture);
@@ -412,7 +433,16 @@ impl Mollusk {
     /// Fixtures provide an API to `decode` a raw blob, as well as read
     /// fixtures from files. Those fixtures can then be provided to this
     /// function to process them and get a Mollusk result.
+    ///
+    /// Note: This is a mutable method on `Mollusk`, since loading a fixture
+    /// into the test environment will alter `Mollusk` values, such as compute
+    /// budget and sysvars. However, the program cache remains unchanged.
+    ///
+    /// Therefore, developers can provision a `Mollusk` instance, set up their
+    /// desired program cache, and then run a series of fixtures against that
+    /// `Mollusk` instance (and cache).
     pub fn process_firedancer_fixture(
+        &mut self,
         fixture: &mollusk_svm_fuzz_fixture_firedancer::Fixture,
     ) -> InstructionResult {
         let (mollusk, instruction, accounts, _) =
@@ -428,7 +458,17 @@ impl Mollusk {
     /// Fixtures provide an API to `decode` a raw blob, as well as read
     /// fixtures from files. Those fixtures can then be provided to this
     /// function to process them and get a Mollusk result.
+    ///
+    ///
+    /// Note: This is a mutable method on `Mollusk`, since loading a fixture
+    /// into the test environment will alter `Mollusk` values, such as compute
+    /// budget and sysvars. However, the program cache remains unchanged.
+    ///
+    /// Therefore, developers can provision a `Mollusk` instance, set up their
+    /// desired program cache, and then run a series of fixtures against that
+    /// `Mollusk` instance (and cache).
     pub fn process_and_validate_firedancer_fixture(
+        &mut self,
         fixture: &mollusk_svm_fuzz_fixture_firedancer::Fixture,
     ) -> InstructionResult {
         let (mollusk, instruction, accounts, result) =

--- a/harness/src/result.rs
+++ b/harness/src/result.rs
@@ -84,7 +84,7 @@ impl InstructionResult {
     }
 
     /// Perform checks on the instruction result, panicking if any checks fail.
-    pub(crate) fn run_checks(&self, checks: &[Check]) {
+    pub fn run_checks(&self, checks: &[Check]) {
         for check in checks {
             match &check.check {
                 CheckType::ComputeUnitsConsumed(units) => {

--- a/harness/src/result.rs
+++ b/harness/src/result.rs
@@ -8,7 +8,7 @@ use solana_sdk::{
 };
 
 /// The result code of the program's execution.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProgramResult {
     /// The program executed successfully.
     Success,
@@ -258,7 +258,7 @@ enum CheckType<'a> {
     /// Check the result code of the program's execution.
     ProgramResult(ProgramResult),
     /// Check the return data produced by executing the instruction.
-    ReturnData(Vec<u8>),
+    ReturnData(&'a [u8]),
     /// Check a resulting account after executing the instruction.
     ResultingAccount(AccountCheck<'a>),
 }
@@ -297,8 +297,13 @@ impl<'a> Check<'a> {
         Check::new(CheckType::ProgramResult(ProgramResult::UnknownError(error)))
     }
 
+    /// Assert that the instruction returned the provided result.
+    pub fn program_result(result: ProgramResult) -> Self {
+        Check::new(CheckType::ProgramResult(result))
+    }
+
     /// Check the return data produced by executing the instruction.
-    pub fn return_data(return_data: Vec<u8>) -> Self {
+    pub fn return_data(return_data: &'a [u8]) -> Self {
         Check::new(CheckType::ReturnData(return_data))
     }
 

--- a/harness/tests/fd_test_vectors.rs
+++ b/harness/tests/fd_test_vectors.rs
@@ -68,13 +68,8 @@ fn test_load_firedancer_fixtures() {
                         slot,
                         ..Default::default()
                     };
-                    let generated_fixture = build_fixture_from_mollusk_test(
-                        &mollusk,
-                        &instruction,
-                        &accounts,
-                        &result,
-                        /* checks */ &[],
-                    );
+                    let generated_fixture =
+                        build_fixture_from_mollusk_test(&mollusk, &instruction, &accounts, &result);
 
                     assert_eq!(loaded_fixture.metadata, generated_fixture.metadata);
                     assert_eq!(

--- a/harness/tests/process_fixture.rs
+++ b/harness/tests/process_fixture.rs
@@ -38,7 +38,6 @@ fn test_process_mollusk() {
         &instruction,
         &accounts,
         &result,
-        &[],
     );
 
     mollusk.process_and_validate_fixture(&fixture);
@@ -52,7 +51,6 @@ fn test_process_mollusk() {
         &instruction,
         &accounts,
         &result,
-        &[],
     );
 
     mollusk.process_and_validate_fixture(&fixture);
@@ -89,7 +87,6 @@ fn test_process_firedancer() {
         &instruction,
         &accounts,
         &result,
-        &[],
     );
 
     mollusk.process_and_validate_firedancer_fixture(&fixture);
@@ -103,7 +100,6 @@ fn test_process_firedancer() {
         &instruction,
         &accounts,
         &result,
-        &[],
     );
 
     mollusk.process_and_validate_firedancer_fixture(&fixture);

--- a/harness/tests/process_fixture.rs
+++ b/harness/tests/process_fixture.rs
@@ -13,7 +13,7 @@ fn test_process_mollusk() {
     let ok_transfer_amount = 42_000;
     let too_much = BASE_LAMPORTS + 1;
 
-    let mollusk = Mollusk::default();
+    let mut mollusk = Mollusk::default();
 
     let sender = Pubkey::new_unique();
     let recipient = Pubkey::new_unique();
@@ -41,7 +41,7 @@ fn test_process_mollusk() {
         &[],
     );
 
-    Mollusk::process_and_validate_fixture(&fixture);
+    mollusk.process_and_validate_fixture(&fixture);
 
     // Now the error case.
     let instruction = system_instruction::transfer(&sender, &recipient, too_much);
@@ -55,7 +55,7 @@ fn test_process_mollusk() {
         &[],
     );
 
-    Mollusk::process_and_validate_fixture(&fixture);
+    mollusk.process_and_validate_fixture(&fixture);
 }
 
 #[cfg(feature = "fuzz-fd")]
@@ -64,7 +64,7 @@ fn test_process_firedancer() {
     let ok_transfer_amount = 42_000;
     let too_much = BASE_LAMPORTS + 1;
 
-    let mollusk = Mollusk::default();
+    let mut mollusk = Mollusk::default();
 
     let sender = Pubkey::new_unique();
     let recipient = Pubkey::new_unique();
@@ -92,7 +92,7 @@ fn test_process_firedancer() {
         &[],
     );
 
-    Mollusk::process_and_validate_firedancer_fixture(&fixture);
+    mollusk.process_and_validate_firedancer_fixture(&fixture);
 
     // Now the error case.
     let instruction = system_instruction::transfer(&sender, &recipient, too_much);
@@ -106,5 +106,5 @@ fn test_process_firedancer() {
         &[],
     );
 
-    Mollusk::process_and_validate_firedancer_fixture(&fixture);
+    mollusk.process_and_validate_firedancer_fixture(&fixture);
 }


### PR DESCRIPTION
When working with fixtures, it's sometimes necessary to configure Mollusk's program cache before running some set of fixtures.

In the current implementation, functions such as `process_and_validate_fixture` are associated functions, so they vend their own new `Mollusk` instance internally and use that for processing the fixture, giving the developer no opportunity to configure the program cache (or any other configurations).

This change makes these functions _methods_ using `&mut self`, which causes the loaded fixture to update the current `Mollusk` instance's configurations based on the fixture.

A few notes:
* For any developers who do _not_ wish to alter their `Mollusk` instance based on loaded fixtures, the `load_fixture` function will no longer vend a `Mollusk` instance, but the components themselves, allowing developers to do with the components what they wish.
* The `run_checks` method on the `InstructionResult` type has been made public, in case comparing all checks in `process_and_validate_fixture` (or any other Mollusk method for that matter) is too strict. Now, one could run just a subset of checks on the returned result from, say, `process_fixture`.

cc @febo 