### PR TITLE
Switch to `Account`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ let instruction = Instruction::new_with_bytes(
 );
 
 let accounts = vec![
-    (key1, AccountSharedData::default()),
-    (key2, AccountSharedData::default()),
+    (key1, Account::default()),
+    (key2, Account::default()),
 ];
 
 let mollusk = Mollusk::new(program_id, "my_program");
@@ -48,11 +48,11 @@ let instruction = system_instruction::transfer(&sender, &recipient, transfer_amo
 let accounts = [
     (
         sender,
-        AccountSharedData::new(base_lamports, 0, &system_program::id()),
+        Account::new(base_lamports, 0, &system_program::id()),
     ),
     (
         recipient,
-        AccountSharedData::new(base_lamports, 0, &system_program::id()),
+        Account::new(base_lamports, 0, &system_program::id()),
     ),
 ];
 let checks = vec![

--- a/bencher/src/lib.rs
+++ b/bencher/src/lib.rs
@@ -5,12 +5,12 @@ mod result;
 use {
     mollusk_svm::{result::ProgramResult, Mollusk},
     result::{write_results, MolluskComputeUnitBenchResult},
-    solana_sdk::{account::AccountSharedData, instruction::Instruction, pubkey::Pubkey},
+    solana_sdk::{account::Account, instruction::Instruction, pubkey::Pubkey},
     std::path::PathBuf,
 };
 
 /// A bench is a tuple of a name, an instruction, and a list of accounts.
-pub type Bench<'a> = (&'a str, &'a Instruction, &'a [(Pubkey, AccountSharedData)]);
+pub type Bench<'a> = (&'a str, &'a Instruction, &'a [(Pubkey, Account)]);
 
 /// Mollusk's compute unit bencher.
 ///

--- a/fuzz/fixture-fd/src/account.rs
+++ b/fuzz/fixture-fd/src/account.rs
@@ -1,12 +1,8 @@
-//! An account with an address: `(Pubkey, AccountSharedData)`.
+//! An account with an address: `(Pubkey, Account)`.
 
 use {
     super::proto::{AcctState as ProtoAccount, SeedAddress as ProtoSeedAddress},
-    solana_sdk::{
-        account::{Account, AccountSharedData},
-        keccak::Hasher,
-        pubkey::Pubkey,
-    },
+    solana_sdk::{account::Account, keccak::Hasher, pubkey::Pubkey},
 };
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -33,7 +29,7 @@ impl From<SeedAddress> for ProtoSeedAddress {
     }
 }
 
-impl From<ProtoAccount> for (Pubkey, AccountSharedData, Option<SeedAddress>) {
+impl From<ProtoAccount> for (Pubkey, Account, Option<SeedAddress>) {
     fn from(value: ProtoAccount) -> Self {
         let ProtoAccount {
             address,
@@ -53,27 +49,27 @@ impl From<ProtoAccount> for (Pubkey, AccountSharedData, Option<SeedAddress>) {
 
         (
             pubkey,
-            AccountSharedData::from(Account {
+            Account {
                 data,
                 executable,
                 lamports,
                 owner,
                 rent_epoch,
-            }),
+            },
             seed_addr.map(Into::into),
         )
     }
 }
 
-impl From<(Pubkey, AccountSharedData, Option<SeedAddress>)> for ProtoAccount {
-    fn from(value: (Pubkey, AccountSharedData, Option<SeedAddress>)) -> Self {
+impl From<(Pubkey, Account, Option<SeedAddress>)> for ProtoAccount {
+    fn from(value: (Pubkey, Account, Option<SeedAddress>)) -> Self {
         let Account {
             lamports,
             data,
             owner,
             executable,
             rent_epoch,
-        } = value.1.into();
+        } = value.1;
 
         ProtoAccount {
             address: value.0.to_bytes().to_vec(),
@@ -87,15 +83,15 @@ impl From<(Pubkey, AccountSharedData, Option<SeedAddress>)> for ProtoAccount {
     }
 }
 
-impl From<(Pubkey, AccountSharedData)> for ProtoAccount {
-    fn from(value: (Pubkey, AccountSharedData)) -> Self {
+impl From<(Pubkey, Account)> for ProtoAccount {
+    fn from(value: (Pubkey, Account)) -> Self {
         let Account {
             lamports,
             data,
             owner,
             executable,
             rent_epoch,
-        } = value.1.into();
+        } = value.1;
 
         ProtoAccount {
             address: value.0.to_bytes().to_vec(),

--- a/fuzz/fixture-fd/src/context.rs
+++ b/fuzz/fixture-fd/src/context.rs
@@ -5,7 +5,7 @@ use {
     },
     crate::account::SeedAddress,
     solana_sdk::{
-        account::AccountSharedData, feature_set::FeatureSet, keccak::Hasher, pubkey::Pubkey,
+        account::Account, feature_set::FeatureSet, keccak::Hasher, pubkey::Pubkey,
         transaction_context::InstructionAccount,
     },
 };
@@ -58,7 +58,7 @@ pub struct Context {
     /// The program ID of the program being invoked.
     pub program_id: Pubkey,
     /// Input accounts with state.
-    pub accounts: Vec<(Pubkey, AccountSharedData, Option<SeedAddress>)>,
+    pub accounts: Vec<(Pubkey, Account, Option<SeedAddress>)>,
     /// Accounts to pass to the instruction.
     pub instruction_accounts: Vec<InstructionAccount>,
     /// The instruction data.
@@ -79,7 +79,7 @@ impl From<ProtoContext> for Context {
             .expect("Invalid bytes for program ID");
         let program_id = Pubkey::new_from_array(program_id_bytes);
 
-        let accounts: Vec<(Pubkey, AccountSharedData, Option<SeedAddress>)> =
+        let accounts: Vec<(Pubkey, Account, Option<SeedAddress>)> =
             value.accounts.into_iter().map(Into::into).collect();
 
         let instruction_accounts: Vec<InstructionAccount> =

--- a/fuzz/fixture-fd/src/effects.rs
+++ b/fuzz/fixture-fd/src/effects.rs
@@ -3,7 +3,7 @@
 use {
     super::proto::InstrEffects as ProtoEffects,
     crate::account::SeedAddress,
-    solana_sdk::{account::AccountSharedData, keccak::Hasher, pubkey::Pubkey},
+    solana_sdk::{account::Account, keccak::Hasher, pubkey::Pubkey},
 };
 
 /// Represents the effects of a single instruction.
@@ -14,7 +14,7 @@ pub struct Effects {
     // Custom error code, also non-zero if any.
     pub program_custom_code: u32,
     /// Copies of accounts that were changed.
-    pub modified_accounts: Vec<(Pubkey, AccountSharedData, Option<SeedAddress>)>,
+    pub modified_accounts: Vec<(Pubkey, Account, Option<SeedAddress>)>,
     /// Compute units available after executing the instruction.
     pub compute_units_available: u64,
     /// Instruction return data.
@@ -31,7 +31,7 @@ impl From<ProtoEffects> for Effects {
             return_data,
         } = value;
 
-        let modified_accounts: Vec<(Pubkey, AccountSharedData, Option<SeedAddress>)> =
+        let modified_accounts: Vec<(Pubkey, Account, Option<SeedAddress>)> =
             modified_accounts.into_iter().map(Into::into).collect();
 
         Self {

--- a/fuzz/fixture-fd/src/lib.rs
+++ b/fuzz/fixture-fd/src/lib.rs
@@ -113,7 +113,7 @@ mod tests {
         },
         mollusk_svm_fuzz_fs::SerializableFixture,
         solana_sdk::{
-            account::AccountSharedData, feature_set::FeatureSet, keccak::Hash, pubkey::Pubkey,
+            account::Account, feature_set::FeatureSet, keccak::Hash, pubkey::Pubkey,
             transaction_context::InstructionAccount,
         },
     };
@@ -131,22 +131,22 @@ mod tests {
         let accounts = vec![
             (
                 Pubkey::new_unique(),
-                AccountSharedData::new(42, 42, &Pubkey::default()),
+                Account::new(42, 42, &Pubkey::default()),
                 None,
             ),
             (
                 Pubkey::new_unique(),
-                AccountSharedData::new(42, 42, &Pubkey::default()),
+                Account::new(42, 42, &Pubkey::default()),
                 None,
             ),
             (
                 Pubkey::new_unique(),
-                AccountSharedData::new(42, 42, &Pubkey::default()),
+                Account::new(42, 42, &Pubkey::default()),
                 None,
             ),
             (
                 Pubkey::new_unique(),
-                AccountSharedData::new(42, 42, &Pubkey::default()),
+                Account::new(42, 42, &Pubkey::default()),
                 None,
             ),
         ];

--- a/fuzz/fixture/src/account.rs
+++ b/fuzz/fixture/src/account.rs
@@ -1,15 +1,11 @@
-//! An account with an address: `(Pubkey, AccountSharedData)`.
+//! An account with an address: `(Pubkey, Account)`.
 
 use {
     super::proto::AcctState as ProtoAccount,
-    solana_sdk::{
-        account::{Account, AccountSharedData},
-        keccak::Hasher,
-        pubkey::Pubkey,
-    },
+    solana_sdk::{account::Account, keccak::Hasher, pubkey::Pubkey},
 };
 
-impl From<ProtoAccount> for (Pubkey, AccountSharedData) {
+impl From<ProtoAccount> for (Pubkey, Account) {
     fn from(value: ProtoAccount) -> Self {
         let ProtoAccount {
             address,
@@ -28,26 +24,26 @@ impl From<ProtoAccount> for (Pubkey, AccountSharedData) {
 
         (
             pubkey,
-            AccountSharedData::from(Account {
+            Account {
                 data,
                 executable,
                 lamports,
                 owner,
                 rent_epoch,
-            }),
+            },
         )
     }
 }
 
-impl From<(Pubkey, AccountSharedData)> for ProtoAccount {
-    fn from(value: (Pubkey, AccountSharedData)) -> Self {
+impl From<(Pubkey, Account)> for ProtoAccount {
+    fn from(value: (Pubkey, Account)) -> Self {
         let Account {
             lamports,
             data,
             owner,
             executable,
             rent_epoch,
-        } = value.1.into();
+        } = value.1;
 
         ProtoAccount {
             address: value.0.to_bytes().to_vec(),

--- a/fuzz/fixture/src/context.rs
+++ b/fuzz/fixture/src/context.rs
@@ -7,8 +7,8 @@ use {
     },
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_sdk::{
-        account::AccountSharedData, feature_set::FeatureSet, instruction::AccountMeta,
-        keccak::Hasher, pubkey::Pubkey,
+        account::Account, feature_set::FeatureSet, instruction::AccountMeta, keccak::Hasher,
+        pubkey::Pubkey,
     },
 };
 
@@ -28,7 +28,7 @@ pub struct Context {
     /// The instruction data.
     pub instruction_data: Vec<u8>,
     /// Input accounts with state.
-    pub accounts: Vec<(Pubkey, AccountSharedData)>,
+    pub accounts: Vec<(Pubkey, Account)>,
 }
 
 impl From<ProtoContext> for Context {
@@ -39,8 +39,7 @@ impl From<ProtoContext> for Context {
             .expect("Invalid bytes for program ID");
         let program_id = Pubkey::new_from_array(program_id_bytes);
 
-        let accounts: Vec<(Pubkey, AccountSharedData)> =
-            value.accounts.into_iter().map(Into::into).collect();
+        let accounts: Vec<(Pubkey, Account)> = value.accounts.into_iter().map(Into::into).collect();
 
         let instruction_accounts: Vec<AccountMeta> = value
             .instr_accounts

--- a/fuzz/fixture/src/effects.rs
+++ b/fuzz/fixture/src/effects.rs
@@ -2,7 +2,7 @@
 
 use {
     super::proto::{AcctState as ProtoAccount, InstrEffects as ProtoEffects},
-    solana_sdk::{account::AccountSharedData, keccak::Hasher, pubkey::Pubkey},
+    solana_sdk::{account::Account, keccak::Hasher, pubkey::Pubkey},
 };
 
 /// Represents the effects of a single instruction.
@@ -16,7 +16,7 @@ pub struct Effects {
     pub program_result: u64,
     pub return_data: Vec<u8>,
     /// Resulting accounts with state, to be checked post-simulation.
-    pub resulting_accounts: Vec<(Pubkey, AccountSharedData)>,
+    pub resulting_accounts: Vec<(Pubkey, Account)>,
 }
 
 impl From<ProtoEffects> for Effects {
@@ -29,7 +29,7 @@ impl From<ProtoEffects> for Effects {
             resulting_accounts,
         } = value;
 
-        let resulting_accounts: Vec<(Pubkey, AccountSharedData)> =
+        let resulting_accounts: Vec<(Pubkey, Account)> =
             resulting_accounts.into_iter().map(Into::into).collect();
 
         Self {

--- a/fuzz/fixture/src/lib.rs
+++ b/fuzz/fixture/src/lib.rs
@@ -97,8 +97,8 @@ mod tests {
         mollusk_svm_fuzz_fs::SerializableFixture,
         solana_compute_budget::compute_budget::ComputeBudget,
         solana_sdk::{
-            account::AccountSharedData, feature_set::FeatureSet, instruction::AccountMeta,
-            keccak::Hash, pubkey::Pubkey,
+            account::Account, feature_set::FeatureSet, instruction::AccountMeta, keccak::Hash,
+            pubkey::Pubkey,
         },
     };
 
@@ -124,12 +124,7 @@ mod tests {
         let instruction_data = vec![4; 24];
         let accounts = instruction_accounts
             .iter()
-            .map(|meta| {
-                (
-                    meta.pubkey,
-                    AccountSharedData::new(42, 42, &Pubkey::default()),
-                )
-            })
+            .map(|meta| (meta.pubkey, Account::new(42, 42, &Pubkey::default())))
             .collect::<Vec<_>>();
 
         let context = Context {

--- a/harness/benches/ips.rs
+++ b/harness/benches/ips.rs
@@ -3,8 +3,8 @@ use {
     criterion::{criterion_group, criterion_main, Criterion, Throughput},
     mollusk_svm::{result::Check, Mollusk},
     solana_sdk::{
-        account::AccountSharedData, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey,
-        system_instruction, system_program,
+        account::Account, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, system_instruction,
+        system_program,
     },
     solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS,
 };
@@ -20,11 +20,11 @@ fn transfer_checked_unchecked(c: &mut Criterion) {
     let accounts = vec![
         (
             sender,
-            AccountSharedData::new(base_lamports, 0, &system_program::id()),
+            Account::new(base_lamports, 0, &system_program::id()),
         ),
         (
             recipient,
-            AccountSharedData::new(base_lamports, 0, &system_program::id()),
+            Account::new(base_lamports, 0, &system_program::id()),
         ),
     ];
     let checks = vec![

--- a/harness/src/accounts.rs
+++ b/harness/src/accounts.rs
@@ -10,7 +10,7 @@ use {
         keys::KeyMap,
     },
     solana_sdk::{
-        account::{AccountSharedData, WritableAccount},
+        account::{Account, WritableAccount},
         instruction::Instruction,
         pubkey::Pubkey,
         transaction_context::{InstructionAccount, TransactionAccount},
@@ -25,11 +25,11 @@ pub struct CompiledAccounts {
 
 pub fn compile_accounts(
     instruction: &Instruction,
-    accounts: &[(Pubkey, AccountSharedData)],
+    accounts: &[(Pubkey, Account)],
     loader_key: Pubkey,
 ) -> CompiledAccounts {
     let stub_out_program_account = move || {
-        let mut program_account = AccountSharedData::default();
+        let mut program_account = Account::default();
         program_account.set_owner(loader_key);
         program_account.set_executable(true);
         program_account

--- a/harness/src/fuzz/firedancer.rs
+++ b/harness/src/fuzz/firedancer.rs
@@ -21,7 +21,7 @@ use {
     },
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_sdk::{
-        account::AccountSharedData,
+        account::Account,
         instruction::{AccountMeta, Instruction, InstructionError},
         pubkey::Pubkey,
     },
@@ -68,7 +68,7 @@ fn num_to_instr_err(num: i32, custom_code: u32) -> InstructionError {
 fn build_fixture_context(
     mollusk: &Mollusk,
     instruction: &Instruction,
-    accounts: &[(Pubkey, AccountSharedData)],
+    accounts: &[(Pubkey, Account)],
 ) -> FuzzContext {
     let Mollusk {
         compute_budget,
@@ -91,7 +91,7 @@ fn build_fixture_context(
 
     let accounts = transaction_accounts
         .into_iter()
-        .map(|(key, account)| (key, account, None))
+        .map(|(key, account)| (key, account.into(), None))
         .collect::<Vec<_>>();
 
     FuzzContext {
@@ -107,9 +107,7 @@ fn build_fixture_context(
     }
 }
 
-fn parse_fixture_context(
-    context: &FuzzContext,
-) -> (Mollusk, Instruction, Vec<(Pubkey, AccountSharedData)>) {
+fn parse_fixture_context(context: &FuzzContext) -> (Mollusk, Instruction, Vec<(Pubkey, Account)>) {
     let FuzzContext {
         program_id,
         accounts,
@@ -199,7 +197,7 @@ fn build_fixture_effects(context: &FuzzContext, result: &InstructionResult) -> F
 
 fn parse_fixture_effects(
     mollusk: &Mollusk,
-    accounts: &[(Pubkey, AccountSharedData)],
+    accounts: &[(Pubkey, Account)],
     effects: &FuzzEffects,
 ) -> InstructionResult {
     let raw_result = if effects.program_result == 0 {
@@ -250,7 +248,7 @@ fn instruction_metadata() -> FuzzMetadata {
 pub fn build_fixture_from_mollusk_test(
     mollusk: &Mollusk,
     instruction: &Instruction,
-    accounts: &[(Pubkey, AccountSharedData)],
+    accounts: &[(Pubkey, Account)],
     result: &InstructionResult,
     _checks: &[Check],
 ) -> FuzzFixture {
@@ -270,7 +268,7 @@ pub fn load_firedancer_fixture(
 ) -> (
     Mollusk,
     Instruction,
-    Vec<(Pubkey, AccountSharedData)>,
+    Vec<(Pubkey, Account)>,
     InstructionResult,
 ) {
     let (mollusk, instruction, accounts) = parse_fixture_context(&fixture.input);

--- a/harness/src/fuzz/mod.rs
+++ b/harness/src/fuzz/mod.rs
@@ -9,13 +9,13 @@ use {
         Mollusk,
     },
     mollusk_svm_fuzz_fs::FsHandler,
-    solana_sdk::{account::AccountSharedData, instruction::Instruction, pubkey::Pubkey},
+    solana_sdk::{account::Account, instruction::Instruction, pubkey::Pubkey},
 };
 
 pub fn generate_fixtures_from_mollusk_test(
     mollusk: &Mollusk,
     instruction: &Instruction,
-    accounts: &[(Pubkey, AccountSharedData)],
+    accounts: &[(Pubkey, Account)],
     result: &InstructionResult,
     checks: &[Check],
 ) {

--- a/harness/src/fuzz/mollusk.rs
+++ b/harness/src/fuzz/mollusk.rs
@@ -15,7 +15,7 @@ use {
         sysvars::Sysvars as FuzzSysvars, Fixture as FuzzFixture,
     },
     solana_sdk::{
-        account::AccountSharedData,
+        account::Account,
         instruction::{Instruction, InstructionError},
         pubkey::Pubkey,
         slot_hashes::SlotHashes,
@@ -106,7 +106,7 @@ impl From<&FuzzEffects> for InstructionResult {
 fn build_fixture_context(
     mollusk: &Mollusk,
     instruction: &Instruction,
-    accounts: &[(Pubkey, AccountSharedData)],
+    accounts: &[(Pubkey, Account)],
 ) -> FuzzContext {
     let Mollusk {
         compute_budget,
@@ -130,9 +130,7 @@ fn build_fixture_context(
     }
 }
 
-fn parse_fixture_context(
-    context: &FuzzContext,
-) -> (Mollusk, Instruction, Vec<(Pubkey, AccountSharedData)>) {
+fn parse_fixture_context(context: &FuzzContext) -> (Mollusk, Instruction, Vec<(Pubkey, Account)>) {
     let FuzzContext {
         compute_budget,
         feature_set,
@@ -161,7 +159,7 @@ fn parse_fixture_context(
 pub fn build_fixture_from_mollusk_test(
     mollusk: &Mollusk,
     instruction: &Instruction,
-    accounts: &[(Pubkey, AccountSharedData)],
+    accounts: &[(Pubkey, Account)],
     result: &InstructionResult,
     _checks: &[Check],
 ) -> FuzzFixture {
@@ -177,7 +175,7 @@ pub fn load_fixture(
 ) -> (
     Mollusk,
     Instruction,
-    Vec<(Pubkey, AccountSharedData)>,
+    Vec<(Pubkey, Account)>,
     InstructionResult,
 ) {
     let (mollusk, instruction, accounts) = parse_fixture_context(&fixture.input);

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -219,22 +219,26 @@ impl Mollusk {
 
         let return_data = transaction_context.get_return_data().1.to_vec();
 
-        let resulting_accounts: Vec<(Pubkey, Account)> = accounts
-            .iter()
-            .map(|(pubkey, account)| {
-                transaction_context
-                    .find_index_of_account(pubkey)
-                    .map(|index| {
-                        let resulting_account = transaction_context
-                            .get_account_at_index(index)
-                            .unwrap()
-                            .take()
-                            .into();
-                        (*pubkey, resulting_account)
-                    })
-                    .unwrap_or((*pubkey, account.clone()))
-            })
-            .collect();
+        let resulting_accounts: Vec<(Pubkey, Account)> = if invoke_result.is_ok() {
+            accounts
+                .iter()
+                .map(|(pubkey, account)| {
+                    transaction_context
+                        .find_index_of_account(pubkey)
+                        .map(|index| {
+                            let resulting_account = transaction_context
+                                .get_account_at_index(index)
+                                .unwrap()
+                                .take()
+                                .into();
+                            (*pubkey, resulting_account)
+                        })
+                        .unwrap_or((*pubkey, account.clone()))
+                })
+                .collect()
+        } else {
+            accounts.to_vec()
+        };
 
         InstructionResult {
             compute_units_consumed,

--- a/harness/src/program.rs
+++ b/harness/src/program.rs
@@ -8,12 +8,8 @@ use {
         loaded_programs::{LoadProgramMetrics, ProgramCacheEntry, ProgramCacheForTxBatch},
     },
     solana_sdk::{
-        account::{Account, AccountSharedData},
-        bpf_loader_upgradeable::UpgradeableLoaderState,
-        feature_set::FeatureSet,
-        native_loader,
-        pubkey::Pubkey,
-        rent::Rent,
+        account::Account, bpf_loader_upgradeable::UpgradeableLoaderState, feature_set::FeatureSet,
+        native_loader, pubkey::Pubkey, rent::Rent,
     },
     std::sync::{Arc, RwLock},
 };
@@ -155,62 +151,62 @@ static BUILTINS: &[Builtin] = &[
 pub fn create_keyed_account_for_builtin_program(
     program_id: &Pubkey,
     name: &str,
-) -> (Pubkey, AccountSharedData) {
+) -> (Pubkey, Account) {
     let data = name.as_bytes().to_vec();
     let lamports = Rent::default().minimum_balance(data.len());
-    let account = AccountSharedData::from(Account {
+    let account = Account {
         lamports,
         data,
         owner: native_loader::id(),
         executable: true,
-        rent_epoch: 0,
-    });
+        ..Default::default()
+    };
     (*program_id, account)
 }
 
 /// Get the key and account for the system program.
-pub fn keyed_account_for_system_program() -> (Pubkey, AccountSharedData) {
+pub fn keyed_account_for_system_program() -> (Pubkey, Account) {
     create_keyed_account_for_builtin_program(&BUILTINS[0].program_id, BUILTINS[0].name)
 }
 
 /// Get the key and account for the BPF Loader v2 program.
-pub fn keyed_account_for_bpf_loader_v2_program() -> (Pubkey, AccountSharedData) {
+pub fn keyed_account_for_bpf_loader_v2_program() -> (Pubkey, Account) {
     create_keyed_account_for_builtin_program(&BUILTINS[1].program_id, BUILTINS[1].name)
 }
 
 /// Get the key and account for the BPF Loader v3 (Upgradeable) program.
-pub fn keyed_account_for_bpf_loader_v3_program() -> (Pubkey, AccountSharedData) {
+pub fn keyed_account_for_bpf_loader_v3_program() -> (Pubkey, Account) {
     create_keyed_account_for_builtin_program(&BUILTINS[1].program_id, BUILTINS[1].name)
 }
 
 /* ... */
 
 /// Create a BPF Loader 1 (deprecated) program account.
-pub fn create_program_account_loader_v1(elf: &[u8]) -> AccountSharedData {
+pub fn create_program_account_loader_v1(elf: &[u8]) -> Account {
     let lamports = Rent::default().minimum_balance(elf.len());
-    AccountSharedData::from(Account {
+    Account {
         lamports,
         data: elf.to_vec(),
         owner: loader_keys::LOADER_V1,
         executable: true,
-        rent_epoch: 0,
-    })
+        ..Default::default()
+    }
 }
 
 /// Create a BPF Loader 2 program account.
-pub fn create_program_account_loader_v2(elf: &[u8]) -> AccountSharedData {
+pub fn create_program_account_loader_v2(elf: &[u8]) -> Account {
     let lamports = Rent::default().minimum_balance(elf.len());
-    AccountSharedData::from(Account {
+    Account {
         lamports,
         data: elf.to_vec(),
         owner: loader_keys::LOADER_V2,
         executable: true,
-        rent_epoch: 0,
-    })
+        ..Default::default()
+    }
 }
 
 /// Create a BPF Loader v3 (Upgradeable) program account.
-pub fn create_program_account_loader_v3(program_id: &Pubkey) -> AccountSharedData {
+pub fn create_program_account_loader_v3(program_id: &Pubkey) -> Account {
     let programdata_address =
         Pubkey::find_program_address(&[program_id.as_ref()], &loader_keys::LOADER_V3).0;
     let data = bincode::serialize(&UpgradeableLoaderState::Program {
@@ -218,17 +214,17 @@ pub fn create_program_account_loader_v3(program_id: &Pubkey) -> AccountSharedDat
     })
     .unwrap();
     let lamports = Rent::default().minimum_balance(data.len());
-    AccountSharedData::from(Account {
+    Account {
         lamports,
         data,
         owner: loader_keys::LOADER_V3,
         executable: true,
-        rent_epoch: 0,
-    })
+        ..Default::default()
+    }
 }
 
 /// Create a BPF Loader v3 (Upgradeable) program data account.
-pub fn create_program_data_account_loader_v3(elf: &[u8]) -> AccountSharedData {
+pub fn create_program_data_account_loader_v3(elf: &[u8]) -> Account {
     let data = {
         let elf_offset = UpgradeableLoaderState::size_of_programdata_metadata();
         let data_len = elf_offset + elf.len();
@@ -245,13 +241,13 @@ pub fn create_program_data_account_loader_v3(elf: &[u8]) -> AccountSharedData {
         data
     };
     let lamports = Rent::default().minimum_balance(data.len());
-    AccountSharedData::from(Account {
+    Account {
         lamports,
         data,
         owner: loader_keys::LOADER_V3,
         executable: false,
-        rent_epoch: 0,
-    })
+        ..Default::default()
+    }
 }
 
 /// Create a BPF Loader v3 (Upgradeable) program and program data account.
@@ -261,7 +257,7 @@ pub fn create_program_data_account_loader_v3(elf: &[u8]) -> AccountSharedData {
 pub fn create_program_account_pair_loader_v3(
     program_id: &Pubkey,
     elf: &[u8],
-) -> (AccountSharedData, AccountSharedData) {
+) -> (Account, Account) {
     (
         create_program_account_loader_v3(program_id),
         create_program_data_account_loader_v3(elf),

--- a/harness/src/result.rs
+++ b/harness/src/result.rs
@@ -1,7 +1,7 @@
 //! Results of Mollusk program execution.
 
 use solana_sdk::{
-    account::{AccountSharedData, ReadableAccount},
+    account::{Account, ReadableAccount},
     instruction::InstructionError,
     program_error::ProgramError,
     pubkey::Pubkey,
@@ -58,7 +58,7 @@ pub struct InstructionResult {
     /// This includes all accounts provided to the processor, in the order
     /// they were provided. Any accounts that were modified will maintain
     /// their original position in this list, but with updated state.
-    pub resulting_accounts: Vec<(Pubkey, AccountSharedData)>,
+    pub resulting_accounts: Vec<(Pubkey, Account)>,
 }
 
 impl Default for InstructionResult {
@@ -76,7 +76,7 @@ impl Default for InstructionResult {
 
 impl InstructionResult {
     /// Get an account from the resulting accounts by its pubkey.
-    pub fn get_account(&self, pubkey: &Pubkey) -> Option<&AccountSharedData> {
+    pub fn get_account(&self, pubkey: &Pubkey) -> Option<&Account> {
         self.resulting_accounts
             .iter()
             .find(|(k, _)| k == pubkey)
@@ -177,7 +177,7 @@ impl InstructionResult {
                         match check_state {
                             AccountStateCheck::Closed => {
                                 assert_eq!(
-                                    &AccountSharedData::default(),
+                                    &Account::default(),
                                     resulting_account,
                                     "CHECK: account closed: got false, expected true"
                                 );

--- a/harness/tests/bpf_program.rs
+++ b/harness/tests/bpf_program.rs
@@ -5,7 +5,7 @@ use {
         Mollusk,
     },
     solana_sdk::{
-        account::AccountSharedData,
+        account::Account,
         incinerator,
         instruction::{AccountMeta, Instruction, InstructionError},
         program_error::ProgramError,
@@ -28,7 +28,7 @@ fn test_write_data() {
     let lamports = mollusk.sysvars.rent.minimum_balance(space);
 
     let key = Pubkey::new_unique();
-    let account = AccountSharedData::new(lamports, space, &program_id);
+    let account = Account::new(lamports, space, &program_id);
 
     let instruction = {
         let mut instruction_data = vec![1];
@@ -91,11 +91,11 @@ fn test_transfer() {
 
     let payer = Pubkey::new_unique();
     let payer_lamports = 100_000_000;
-    let payer_account = AccountSharedData::new(payer_lamports, 0, &system_program::id());
+    let payer_account = Account::new(payer_lamports, 0, &system_program::id());
 
     let recipient = Pubkey::new_unique();
     let recipient_lamports = 0;
-    let recipient_account = AccountSharedData::new(recipient_lamports, 0, &system_program::id());
+    let recipient_account = Account::new(recipient_lamports, 0, &system_program::id());
 
     let transfer_amount = 2_000_000_u64;
 
@@ -134,7 +134,7 @@ fn test_transfer() {
         mollusk.process_and_validate_instruction(
             &instruction,
             &[
-                (payer, AccountSharedData::default()),
+                (payer, Account::default()),
                 (recipient, recipient_account.clone()),
                 keyed_account_for_system_program(),
             ],
@@ -174,7 +174,7 @@ fn test_close_account() {
     let mollusk = Mollusk::new(&program_id, "test_program_primary");
 
     let key = Pubkey::new_unique();
-    let account = AccountSharedData::new(50_000_000, 50, &program_id);
+    let account = Account::new(50_000_000, 50, &program_id);
 
     let instruction = Instruction::new_with_bytes(
         program_id,
@@ -195,7 +195,7 @@ fn test_close_account() {
             &account_not_signer_ix,
             &[
                 (key, account.clone()),
-                (incinerator::id(), AccountSharedData::default()),
+                (incinerator::id(), Account::default()),
                 keyed_account_for_system_program(),
             ],
             &[Check::err(ProgramError::MissingRequiredSignature)],
@@ -207,7 +207,7 @@ fn test_close_account() {
         &instruction,
         &[
             (key, account.clone()),
-            (incinerator::id(), AccountSharedData::default()),
+            (incinerator::id(), Account::default()),
             keyed_account_for_system_program(),
         ],
         &[
@@ -238,7 +238,7 @@ fn test_cpi() {
     let lamports = mollusk.sysvars.rent.minimum_balance(space);
 
     let key = Pubkey::new_unique();
-    let account = AccountSharedData::new(lamports, space, &cpi_target_program_id);
+    let account = Account::new(lamports, space, &cpi_target_program_id);
 
     let instruction = {
         let mut instruction_data = vec![4];
@@ -365,10 +365,7 @@ fn test_account_dedupe() {
         );
         mollusk.process_and_validate_instruction(
             &instruction,
-            &[
-                (key, AccountSharedData::default()),
-                (key, AccountSharedData::default()),
-            ],
+            &[(key, Account::default()), (key, Account::default())],
             &[Check::success()],
         );
     }
@@ -385,10 +382,7 @@ fn test_account_dedupe() {
         );
         mollusk.process_and_validate_instruction(
             &instruction,
-            &[
-                (key, AccountSharedData::default()),
-                (key, AccountSharedData::default()),
-            ],
+            &[(key, Account::default()), (key, Account::default())],
             &[Check::success()],
         );
     }
@@ -405,10 +399,7 @@ fn test_account_dedupe() {
         );
         mollusk.process_and_validate_instruction(
             &instruction,
-            &[
-                (key, AccountSharedData::default()),
-                (key, AccountSharedData::default()),
-            ],
+            &[(key, Account::default()), (key, Account::default())],
             &[Check::success()],
         );
     }

--- a/harness/tests/dump_fixture.rs
+++ b/harness/tests/dump_fixture.rs
@@ -4,8 +4,8 @@ use {
     mollusk_svm::{result::Check, Mollusk},
     serial_test::serial,
     solana_sdk::{
-        account::AccountSharedData, feature_set::FeatureSet, instruction::Instruction,
-        pubkey::Pubkey, system_instruction, system_program,
+        account::Account, feature_set::FeatureSet, instruction::Instruction, pubkey::Pubkey,
+        system_instruction, system_program,
     },
     std::path::Path,
 };
@@ -73,7 +73,7 @@ const TRANSFER_AMOUNT: u64 = 42_000;
 struct TestSetup<'a> {
     mollusk: Mollusk,
     instruction: Instruction,
-    accounts: Vec<(Pubkey, AccountSharedData)>,
+    accounts: Vec<(Pubkey, Account)>,
     checks: Vec<Check<'a>>,
 }
 
@@ -85,11 +85,11 @@ impl<'a> TestSetup<'a> {
         let accounts = vec![
             (
                 *sender,
-                AccountSharedData::new(BASE_LAMPORTS, 0, &system_program::id()),
+                Account::new(BASE_LAMPORTS, 0, &system_program::id()),
             ),
             (
                 *recipient,
-                AccountSharedData::new(BASE_LAMPORTS, 0, &system_program::id()),
+                Account::new(BASE_LAMPORTS, 0, &system_program::id()),
             ),
         ];
         let checks = vec![

--- a/harness/tests/fd_test_vectors.rs
+++ b/harness/tests/fd_test_vectors.rs
@@ -5,7 +5,7 @@ use {
     mollusk_svm_fuzz_fixture_firedancer::{account::SeedAddress, Fixture},
     rayon::prelude::*,
     solana_sdk::{
-        account::AccountSharedData, feature_set::FeatureSet, pubkey::Pubkey,
+        account::Account, feature_set::FeatureSet, pubkey::Pubkey,
         transaction_context::InstructionAccount,
     },
     std::{assert_eq, fs, path::Path, process::Command},
@@ -112,8 +112,8 @@ fn test_load_firedancer_fixtures() {
 }
 
 fn compare_accounts(
-    a: &[(Pubkey, AccountSharedData, Option<SeedAddress>)],
-    b: &[(Pubkey, AccountSharedData, Option<SeedAddress>)],
+    a: &[(Pubkey, Account, Option<SeedAddress>)],
+    b: &[(Pubkey, Account, Option<SeedAddress>)],
 ) -> bool {
     if a.len() != b.len() {
         return false;

--- a/harness/tests/instruction_chain.rs
+++ b/harness/tests/instruction_chain.rs
@@ -1,7 +1,7 @@
 use {
     mollusk_svm::{program::keyed_account_for_system_program, result::Check, Mollusk},
     solana_sdk::{
-        account::AccountSharedData,
+        account::Account,
         incinerator,
         instruction::{AccountMeta, Instruction},
         pubkey::Pubkey,
@@ -9,8 +9,8 @@ use {
     },
 };
 
-fn system_account_with_lamports(lamports: u64) -> AccountSharedData {
-    AccountSharedData::new(lamports, 0, &system_program::id())
+fn system_account_with_lamports(lamports: u64) -> Account {
+    Account::new(lamports, 0, &system_program::id())
 }
 
 #[test]
@@ -129,9 +129,9 @@ fn test_mixed() {
         ],
         &[
             (payer, system_account_with_lamports(lamports * 4)),
-            (target1, AccountSharedData::default()),
-            (target2, AccountSharedData::default()),
-            (incinerator::id(), AccountSharedData::default()),
+            (target1, Account::default()),
+            (target2, Account::default()),
+            (incinerator::id(), Account::default()),
             keyed_account_for_system_program(),
         ],
         &[

--- a/harness/tests/precompile.rs
+++ b/harness/tests/precompile.rs
@@ -2,7 +2,7 @@ use {
     mollusk_svm::{result::Check, Mollusk},
     rand0_7::thread_rng,
     solana_sdk::{
-        account::{AccountSharedData, WritableAccount},
+        account::{Account, WritableAccount},
         ed25519_instruction::new_ed25519_instruction,
         ed25519_program, native_loader,
         pubkey::Pubkey,
@@ -11,8 +11,8 @@ use {
     },
 };
 
-fn precompile_account() -> AccountSharedData {
-    let mut account = AccountSharedData::new(1, 0, &native_loader::id());
+fn precompile_account() -> Account {
+    let mut account = Account::new(1, 0, &native_loader::id());
     account.set_executable(true);
     account
 }
@@ -25,7 +25,7 @@ fn test_secp256k1() {
     mollusk.process_and_validate_instruction(
         &new_secp256k1_instruction(&secret_key, b"hello"),
         &[
-            (Pubkey::new_unique(), AccountSharedData::default()),
+            (Pubkey::new_unique(), Account::default()),
             (secp256k1_program::id(), precompile_account()),
         ],
         &[Check::success()],
@@ -40,7 +40,7 @@ fn test_ed25519() {
     mollusk.process_and_validate_instruction(
         &new_ed25519_instruction(&secret_key, b"hello"),
         &[
-            (Pubkey::new_unique(), AccountSharedData::default()),
+            (Pubkey::new_unique(), Account::default()),
             (ed25519_program::id(), precompile_account()),
         ],
         &[Check::success()],

--- a/harness/tests/process_fixture.rs
+++ b/harness/tests/process_fixture.rs
@@ -2,7 +2,7 @@
 
 use {
     mollusk_svm::Mollusk,
-    solana_sdk::{account::AccountSharedData, pubkey::Pubkey, system_instruction, system_program},
+    solana_sdk::{account::Account, pubkey::Pubkey, system_instruction, system_program},
 };
 
 const BASE_LAMPORTS: u64 = 100_000_000;
@@ -21,11 +21,11 @@ fn test_process_mollusk() {
     let accounts = vec![
         (
             sender,
-            AccountSharedData::new(BASE_LAMPORTS, 0, &system_program::id()),
+            Account::new(BASE_LAMPORTS, 0, &system_program::id()),
         ),
         (
             recipient,
-            AccountSharedData::new(BASE_LAMPORTS, 0, &system_program::id()),
+            Account::new(BASE_LAMPORTS, 0, &system_program::id()),
         ),
     ];
 
@@ -72,11 +72,11 @@ fn test_process_firedancer() {
     let accounts = vec![
         (
             sender,
-            AccountSharedData::new(BASE_LAMPORTS, 0, &system_program::id()),
+            Account::new(BASE_LAMPORTS, 0, &system_program::id()),
         ),
         (
             recipient,
-            AccountSharedData::new(BASE_LAMPORTS, 0, &system_program::id()),
+            Account::new(BASE_LAMPORTS, 0, &system_program::id()),
         ),
     ];
 

--- a/harness/tests/system_program.rs
+++ b/harness/tests/system_program.rs
@@ -1,8 +1,8 @@
 use {
     mollusk_svm::{result::Check, Mollusk},
     solana_sdk::{
-        account::AccountSharedData, instruction::InstructionError, pubkey::Pubkey,
-        system_instruction, system_program,
+        account::Account, instruction::InstructionError, pubkey::Pubkey, system_instruction,
+        system_program,
     },
     solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS,
 };
@@ -19,11 +19,11 @@ fn test_transfer() {
     let accounts = [
         (
             sender,
-            AccountSharedData::new(base_lamports, 0, &system_program::id()),
+            Account::new(base_lamports, 0, &system_program::id()),
         ),
         (
             recipient,
-            AccountSharedData::new(base_lamports, 0, &system_program::id()),
+            Account::new(base_lamports, 0, &system_program::id()),
         ),
     ];
     let checks = vec![
@@ -54,11 +54,11 @@ fn test_transfer_account_ordering() {
     let accounts = [
         (
             recipient,
-            AccountSharedData::new(base_lamports, 0, &system_program::id()),
+            Account::new(base_lamports, 0, &system_program::id()),
         ),
         (
             sender,
-            AccountSharedData::new(base_lamports, 0, &system_program::id()),
+            Account::new(base_lamports, 0, &system_program::id()),
         ),
     ];
     let checks = vec![
@@ -87,11 +87,11 @@ fn test_transfer_bad_owner() {
     let accounts = [
         (
             sender,
-            AccountSharedData::new(base_lamports, 0, &Pubkey::new_unique()), // <-- Bad owner.
+            Account::new(base_lamports, 0, &Pubkey::new_unique()), // <-- Bad owner.
         ),
         (
             recipient,
-            AccountSharedData::new(base_lamports, 0, &system_program::id()),
+            Account::new(base_lamports, 0, &system_program::id()),
         ),
     ];
     let checks = vec![

--- a/programs/memo/src/memo.rs
+++ b/programs/memo/src/memo.rs
@@ -1,6 +1,6 @@
 use {
     mollusk_svm::Mollusk,
-    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+    solana_sdk::{account::Account, pubkey::Pubkey},
 };
 
 pub const ID: Pubkey = solana_sdk::pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
@@ -16,12 +16,12 @@ pub fn add_program(mollusk: &mut Mollusk) {
     );
 }
 
-pub fn account() -> AccountSharedData {
+pub fn account() -> Account {
     // Loader v2
     mollusk_svm::program::create_program_account_loader_v2(ELF)
 }
 
 /// Get the key and account for the SPL Memo program.
-pub fn keyed_account() -> (Pubkey, AccountSharedData) {
+pub fn keyed_account() -> (Pubkey, Account) {
     (ID, account())
 }

--- a/programs/memo/src/memo_v1.rs
+++ b/programs/memo/src/memo_v1.rs
@@ -1,6 +1,6 @@
 use {
     mollusk_svm::Mollusk,
-    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+    solana_sdk::{account::Account, pubkey::Pubkey},
 };
 
 pub const ID: Pubkey = solana_sdk::pubkey!("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo");
@@ -16,12 +16,12 @@ pub fn add_program(mollusk: &mut Mollusk) {
     );
 }
 
-pub fn account() -> AccountSharedData {
+pub fn account() -> Account {
     // Loader v1
     mollusk_svm::program::create_program_account_loader_v1(ELF)
 }
 
 /// Get the key and account for the SPL Memo program V1.
-pub fn keyed_account() -> (Pubkey, AccountSharedData) {
+pub fn keyed_account() -> (Pubkey, Account) {
     (ID, account())
 }

--- a/programs/token/src/associated_token.rs
+++ b/programs/token/src/associated_token.rs
@@ -1,6 +1,6 @@
 use {
     mollusk_svm::Mollusk,
-    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+    solana_sdk::{account::Account, pubkey::Pubkey},
 };
 
 pub const ID: Pubkey = solana_sdk::pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
@@ -16,12 +16,12 @@ pub fn add_program(mollusk: &mut Mollusk) {
     );
 }
 
-pub fn account() -> AccountSharedData {
+pub fn account() -> Account {
     // Loader v2
     mollusk_svm::program::create_program_account_loader_v2(ELF)
 }
 
 /// Get the key and account for the SPL Associated Token program.
-pub fn keyed_account() -> (Pubkey, AccountSharedData) {
+pub fn keyed_account() -> (Pubkey, Account) {
     (ID, account())
 }

--- a/programs/token/src/token.rs
+++ b/programs/token/src/token.rs
@@ -1,6 +1,6 @@
 use {
     mollusk_svm::Mollusk,
-    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+    solana_sdk::{account::Account, pubkey::Pubkey},
 };
 
 pub const ID: Pubkey = solana_sdk::pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
@@ -16,12 +16,12 @@ pub fn add_program(mollusk: &mut Mollusk) {
     );
 }
 
-pub fn account() -> AccountSharedData {
+pub fn account() -> Account {
     // Loader v2
     mollusk_svm::program::create_program_account_loader_v2(ELF)
 }
 
 /// Get the key and account for the SPL Token program.
-pub fn keyed_account() -> (Pubkey, AccountSharedData) {
+pub fn keyed_account() -> (Pubkey, Account) {
     (ID, account())
 }

--- a/programs/token/src/token2022.rs
+++ b/programs/token/src/token2022.rs
@@ -1,6 +1,6 @@
 use {
     mollusk_svm::Mollusk,
-    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+    solana_sdk::{account::Account, pubkey::Pubkey},
 };
 
 pub const ID: Pubkey = solana_sdk::pubkey!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
@@ -16,12 +16,12 @@ pub fn add_program(mollusk: &mut Mollusk) {
     );
 }
 
-pub fn account() -> AccountSharedData {
+pub fn account() -> Account {
     // Loader v3
     mollusk_svm::program::create_program_account_loader_v3(&ID)
 }
 
 /// Get the key and account for the SPL Token-2022 program.
-pub fn keyed_account() -> (Pubkey, AccountSharedData) {
+pub fn keyed_account() -> (Pubkey, Account) {
     (ID, account())
 }


### PR DESCRIPTION
This change switches from `AccountSharedData` to `Account`, as well as only returns modified accounts in the result if the program passes.

@febo 