### PR TITLE
support fuzz fixtures in ix chains

### DIFF
--- a/harness/src/result.rs
+++ b/harness/src/result.rs
@@ -207,6 +207,15 @@ impl InstructionResult {
         }
     }
 
+    pub(crate) fn absorb(&mut self, other: Self) {
+        self.compute_units_consumed += other.compute_units_consumed;
+        self.execution_time += other.execution_time;
+        self.program_result = other.program_result;
+        self.raw_result = other.raw_result;
+        self.return_data = other.return_data;
+        self.resulting_accounts = other.resulting_accounts;
+    }
+
     /// Compare an `InstructionResult` against another `InstructionResult`,
     /// panicking on any mismatches.
     pub fn compare(&self, b: &Self) {

--- a/harness/tests/dump_fixture.rs
+++ b/harness/tests/dump_fixture.rs
@@ -195,6 +195,34 @@ fn test_dump_mollusk() {
     // Ensure both files have the same name.
     assert_filenames_match(&blob_fixture_path, &json_fixture_path);
 
+    // Now check instruction chains.
+    clear(EJECT_FUZZ_FIXTURES);
+
+    setup.mollusk.process_and_validate_instruction_chain(
+        &[
+            (&setup.instruction, &[]),
+            (&setup.instruction, &[]),
+            (&setup.instruction, &[]),
+        ],
+        &setup.accounts,
+    );
+
+    // Ensure there are three of each fixture type in the target directory.
+    let dir = std::fs::read_dir(EJECT_FUZZ_FIXTURES).unwrap();
+    let mut count_blob = 0;
+    let mut count_json = 0;
+    for entry in dir {
+        let path = entry.unwrap().path();
+        if is_fixture_file(&path, &FileType::Blob) {
+            count_blob += 1;
+        }
+        if is_fixture_file(&path, &FileType::Json) {
+            count_json += 1;
+        }
+    }
+    assert_eq!(count_blob, 3);
+    assert_eq!(count_json, 3);
+
     std::env::remove_var("EJECT_FUZZ_FIXTURES");
     std::env::remove_var("EJECT_FUZZ_FIXTURES_JSON");
     clear(EJECT_FUZZ_FIXTURES);
@@ -234,6 +262,34 @@ fn test_dump_firedancer() {
 
     // Ensure both files have the same name.
     assert_filenames_match(&blob_fixture_path, &json_fixture_path);
+
+    // Now check instruction chains.
+    clear(EJECT_FUZZ_FIXTURES_FD);
+
+    setup.mollusk.process_and_validate_instruction_chain(
+        &[
+            (&setup.instruction, &[]),
+            (&setup.instruction, &[]),
+            (&setup.instruction, &[]),
+        ],
+        &setup.accounts,
+    );
+
+    // Ensure there are three of each fixture type in the target directory.
+    let dir = std::fs::read_dir(EJECT_FUZZ_FIXTURES_FD).unwrap();
+    let mut count_blob = 0;
+    let mut count_json = 0;
+    for entry in dir {
+        let path = entry.unwrap().path();
+        if is_fixture_file(&path, &FileType::Blob) {
+            count_blob += 1;
+        }
+        if is_fixture_file(&path, &FileType::Json) {
+            count_json += 1;
+        }
+    }
+    assert_eq!(count_blob, 3);
+    assert_eq!(count_json, 3);
 
     std::env::remove_var("EJECT_FUZZ_FIXTURES_FD");
     std::env::remove_var("EJECT_FUZZ_FIXTURES_JSON_FD");

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 agave-install init 2.1.0
 rm -rf target
 cargo build


### PR DESCRIPTION
Reimplementation of #73 from [this suggestion](https://github.com/buffalojoec/mollusk/pull/73#pullrequestreview-2546863518) from @febo.

---

This change adjusts the internals of the instruction chain API to support generation of fuzzing fixtures.

Additionally, since checks will play a key role in fixtures down the road, this change also adjusts the API for instruction chains, allowing developers to declare a slice of `Check` for each instruction in the chain separately.